### PR TITLE
Introduce parser library method to parse list of region arguments

### DIFF
--- a/include/mlir/IR/OpImplementation.h
+++ b/include/mlir/IR/OpImplementation.h
@@ -315,8 +315,8 @@ public:
   /// Parse a single operand.
   virtual ParseResult parseOperand(OperandType &result) = 0;
 
-  /// These are the supported delimiters around operand lists, used by
-  /// parseOperandList.
+  /// These are the supported delimiters around operand lists and region
+  /// argument lists, used by parseOperandList and parseRegionArgumentList.
   enum class Delimiter {
     /// Zero or more operands with no delimiters.
     None,
@@ -410,9 +410,24 @@ public:
                                           ArrayRef<OperandType> arguments,
                                           ArrayRef<Type> argTypes) = 0;
 
-  /// Parse a region argument.  Region arguments define new values, so this also
-  /// checks if the values with the same name has not been defined yet.
+  /// Parse a region argument.  Region arguments define new values; so this also
+  /// checks if values with the same name have not been defined yet.
   virtual ParseResult parseRegionArgument(OperandType &argument) = 0;
+
+  /// Parse zero or more region arguments with a specified surrounding
+  /// delimiter, and an optional required argument count. Region arguments
+  /// define new values; so this also checks if values with the same names have
+  /// not been defined yet.
+  virtual ParseResult
+  parseRegionArgumentList(SmallVectorImpl<OperandType> &result,
+                          int requiredOperandCount = -1,
+                          Delimiter delimiter = Delimiter::None) = 0;
+  virtual ParseResult
+  parseRegionArgumentList(SmallVectorImpl<OperandType> &result,
+                          Delimiter delimiter) {
+    return parseRegionArgumentList(result, /*requiredOperandCount=*/-1,
+                                   delimiter);
+  }
 
   /// Parse a region argument if present.
   virtual ParseResult parseOptionalRegionArgument(OperandType &argument) = 0;
@@ -486,6 +501,14 @@ public:
     result.append(types.begin(), types.end());
     return success();
   }
+
+private:
+  /// Parse either an operand list or a region argument list depending on
+  /// whether `operand' is true.
+  ParseResult parseOperandOrRegionArgList(SmallVectorImpl<OperandType> &result,
+                                          bool isOperandList,
+                                          int requiredOperandCount,
+                                          Delimiter delimiter);
 };
 
 } // end namespace mlir

--- a/lib/GPU/IR/GPUDialect.cpp
+++ b/lib/GPU/IR/GPUDialect.cpp
@@ -221,12 +221,13 @@ parseSizeAssignment(OpAsmParser *parser,
                     MutableArrayRef<OpAsmParser::OperandType> sizes,
                     MutableArrayRef<OpAsmParser::OperandType> regionSizes,
                     MutableArrayRef<OpAsmParser::OperandType> indices) {
-  if (parser->parseLParen() || parser->parseRegionArgument(indices[0]) ||
-      parser->parseComma() || parser->parseRegionArgument(indices[1]) ||
-      parser->parseComma() || parser->parseRegionArgument(indices[2]) ||
-      parser->parseRParen() || parser->parseKeyword("in") ||
-      parser->parseLParen())
+  assert(indices.size() == 3 && "space for three indices expected");
+  SmallVector<OpAsmParser::OperandType, 3> args;
+  if (parser->parseRegionArgumentList(args, /*requiredOperandCount=*/3,
+                                      OpAsmParser::Delimiter::Paren) ||
+      parser->parseKeyword("in") || parser->parseLParen())
     return failure();
+  std::move(args.begin(), args.end(), indices.begin());
 
   for (int i = 0; i < 3; ++i) {
     if (i != 0 && parser->parseComma())

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -3344,6 +3344,16 @@ public:
   ParseResult parseOperandList(SmallVectorImpl<OperandType> &result,
                                int requiredOperandCount = -1,
                                Delimiter delimiter = Delimiter::None) override {
+    return parseOperandOrRegionArgList(result, /*isOperandList=*/true,
+                                       requiredOperandCount, delimiter);
+  }
+
+  /// Parse zero or more SSA comma-separated operand references with a specified
+  /// surrounding delimiter, and an optional required operand count.
+  ParseResult
+  parseOperandOrRegionArgList(SmallVectorImpl<OperandType> &result,
+                              bool isOperandList, int requiredOperandCount = -1,
+                              Delimiter delimiter = Delimiter::None) {
     auto startLoc = parser.getToken().getLoc();
 
     // Handle delimiters.
@@ -3382,10 +3392,11 @@ public:
     // Check for zero operands.
     if (parser.getToken().is(Token::percent_identifier)) {
       do {
-        OperandType operand;
-        if (parseOperand(operand))
+        OperandType operandOrArg;
+        if (isOperandList ? parseOperand(operandOrArg)
+                          : parseRegionArgument(operandOrArg))
           return failure();
-        result.push_back(operand);
+        result.push_back(operandOrArg);
       } while (parser.consumeIf(Token::comma));
     }
 
@@ -3537,6 +3548,14 @@ public:
     if (parser.getToken().isNot(Token::percent_identifier))
       return success();
     return parseRegionArgument(argument);
+  }
+
+  ParseResult
+  parseRegionArgumentList(SmallVectorImpl<OperandType> &result,
+                          int requiredOperandCount = -1,
+                          Delimiter delimiter = Delimiter::None) override {
+    return parseOperandOrRegionArgList(result, /*isOperandList=*/false,
+                                       requiredOperandCount, delimiter);
   }
 
   //===--------------------------------------------------------------------===//

--- a/test/Transforms/test-legalizer.mlir
+++ b/test/Transforms/test-legalizer.mlir
@@ -133,3 +133,18 @@ func @fail_to_convert_region() {
   }) : () -> ()
   return
 }
+
+// -----
+
+// Test parsing of an op with multiple region arguments, and without a
+// delimiter.
+
+// CHECK-LABEL: func @op_with_region_args
+func @op_with_region_args() {
+  // CHECK: "test.polyfor"() ( {
+  // CHECK-NEXT:  ^bb0(%arg0: index, %arg1: index, %arg2: index):
+  test.polyfor %i, %j, %k {
+    "foo"() : () -> ()
+  }
+  return
+}

--- a/test/lib/TestDialect/TestDialect.cpp
+++ b/test/lib/TestDialect/TestDialect.cpp
@@ -34,6 +34,25 @@ TestDialect::TestDialect(MLIRContext *context)
   allowUnknownOperations();
 }
 
+//===----------------------------------------------------------------------===//
+// Test PolyForOp - parse list of region arguments.
+//===----------------------------------------------------------------------===//
+ParseResult parsePolyForOp(OpAsmParser *parser, OperationState *result) {
+  SmallVector<OpAsmParser::OperandType, 4> ivsInfo;
+  // Parse list of region arguments without a delimiter.
+  if (parser->parseRegionArgumentList(ivsInfo))
+    return failure();
+
+  // Parse the body region.
+  Region *body = result->addRegion();
+  auto &builder = parser->getBuilder();
+  SmallVector<Type, 4> argTypes(ivsInfo.size(), builder.getIndexType());
+  if (parser->parseRegion(*body, ivsInfo, argTypes))
+    return failure();
+
+  return success();
+}
+
 // Static initialization for Test dialect registration.
 static mlir::DialectRegistration<mlir::TestDialect> testDialect;
 

--- a/test/lib/TestDialect/TestOps.td
+++ b/test/lib/TestDialect/TestOps.td
@@ -459,4 +459,19 @@ def TestInvalidOp : TEST_Op<"invalid", [Terminator]>,
 def TestValidOp : TEST_Op<"valid", [Terminator]>,
   Arguments<(ins Variadic<AnyType>:$inputs)>;
 
+//===----------------------------------------------------------------------===//
+// Test region argument list parsing.
+//===----------------------------------------------------------------------===//
+
+def PolyForOp : TEST_Op<"polyfor">
+{
+  let summary =  "polyfor operation";
+  let description = [{
+    Test op with multiple region arguments, each argument of index type.
+  }];
+
+  let regions = (region SizedRegion<1>:$region);
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+}
+
 #endif // TEST_OPS


### PR DESCRIPTION
- introduce parseRegionArgumentList (similar to parseOperandList) to parse a
  list of region arguments with a delimiter
- allows defining custom parse for op's with multiple/variadic number of
  region arguments
- use this on the gpu.launch op (although the latter has a fixed number
  of region arguments)

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>