### PR TITLE
Configurable call-back method name for AllocOp and DeallocOp

### DIFF
--- a/include/mlir/StandardOps/Ops.td
+++ b/include/mlir/StandardOps/Ops.td
@@ -148,14 +148,28 @@ def AllocOp : Std_Op<"alloc"> {
   let arguments = (ins Variadic<Index>:$value);
   let results = (outs AnyMemRef);
 
-  let builders = [OpBuilder<
+  let builders = [
+  OpBuilder<
     "Builder *builder, OperationState *result, MemRefType memrefType", [{
-       result->types.push_back(memrefType);
-     }]
-  >];
+      result->types.push_back(memrefType);
+    }]>,
+  OpBuilder<
+    "Builder *builder, OperationState *result, MemRefType memrefType, "
+    "StringRef callbackName", [{
+      result->types.push_back(memrefType);
+      assert(callbackName != "");
+      result->addAttribute("callbackName", builder->getSymbolRefAttr(callbackName));
+    }]>
+  ];
 
   let extraClassDeclaration = [{
     MemRefType getType() { return getResult()->getType().cast<MemRefType>(); }
+    StringRef getCallbackName() { 
+      Attribute attr = getAttr("callbackName");
+      if (attr == Attribute(nullptr))
+        return "";
+      return attr.cast<mlir::StringAttr>().getValue();
+    }
   }];
 
   let hasCanonicalizer = 1;
@@ -524,6 +538,24 @@ def DeallocOp : Std_Op<"dealloc"> {
   let arguments = (ins AnyMemRef:$memref);
 
   let hasCanonicalizer = 1;
+
+  let builders = [OpBuilder<
+    "Builder *builder, OperationState *result, Value* memref, "
+    "StringRef callbackName", [{
+      result->operands.push_back(memref);
+      assert (callbackName != "");
+      result->addAttribute("callbackName", builder->getSymbolRefAttr(callbackName));
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+  StringRef getCallbackName() { 
+    Attribute attr = getAttr("callbackName");
+    if (attr == Attribute(nullptr))
+      return "";
+    return attr.cast<mlir::StringAttr>().getValue();
+  }
+  }];
 }
 
 def DimOp : Std_Op<"dim", [NoSideEffect]> {

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -478,14 +478,19 @@ struct AllocOpLowering : public LLVMLegalizationPattern<AllocOp> {
             cumulativeSize,
             createIndexConstant(rewriter, op->getLoc(), elementSize)});
 
-    // Insert the `malloc` declaration if it is not already present.
+    // Insert the alloc callback declaration if it is not already present.
     auto module = op->getParentOfType<ModuleOp>();
-    FuncOp mallocFunc = module.lookupSymbol<FuncOp>("malloc");
+    StringRef allocFuncName = allocOp.getCallbackName();
+
+    if (allocFuncName == "")
+      allocFuncName = "malloc";
+
+    FuncOp mallocFunc = module.lookupSymbol<FuncOp>(allocFuncName);
     if (!mallocFunc) {
       auto mallocType =
           rewriter.getFunctionType(getIndexType(), getVoidPtrType());
       mallocFunc =
-          FuncOp::create(rewriter.getUnknownLoc(), "malloc", mallocType);
+          FuncOp::create(rewriter.getUnknownLoc(), allocFuncName, mallocType);
       module.push_back(mallocFunc);
     }
 
@@ -541,12 +546,18 @@ struct DeallocOpLowering : public LLVMLegalizationPattern<DeallocOp> {
     assert(operands.size() == 1 && "dealloc takes one operand");
     OperandAdaptor<DeallocOp> transformed(operands);
 
-    // Insert the `free` declaration if it is not already present.
+    
+    auto deallocOp = cast<DeallocOp>(op);
+    StringRef callbackName = deallocOp.getCallbackName();
+    if (callbackName == "")
+      callbackName = "free";
+
+      // Insert the free call-back declaration if it is not already present.
     FuncOp freeFunc =
-        op->getParentOfType<ModuleOp>().lookupSymbol<FuncOp>("free");
+        op->getParentOfType<ModuleOp>().lookupSymbol<FuncOp>(callbackName);
     if (!freeFunc) {
       auto freeType = rewriter.getFunctionType(getVoidPtrType(), {});
-      freeFunc = FuncOp::create(rewriter.getUnknownLoc(), "free", freeType);
+      freeFunc = FuncOp::create(rewriter.getUnknownLoc(), callbackName, freeType);
       op->getParentOfType<ModuleOp>().push_back(freeFunc);
     }
 

--- a/lib/StandardOps/Ops.cpp
+++ b/lib/StandardOps/Ops.cpp
@@ -1218,6 +1218,7 @@ static ParseResult parseDeallocOp(OpAsmParser *parser, OperationState *result) {
   MemRefType type;
 
   return failure(parser->parseOperand(memrefInfo) ||
+                 parser->parseOptionalAttributeDict(result->attributes) ||
                  parser->parseColonType(type) ||
                  parser->resolveOperand(memrefInfo, type, result->operands));
 }


### PR DESCRIPTION
Currently Alloc/Dealloc in standard dialect are hard-coded to call malloc/free. This change adds a string attribute to the operations to hold the callback name allowing use of custom allocators. Added overloaded builders to set the attribute, and getters. 

If the attribute is missing, `malloc/free` are used by default.  The call signature remains unchanged `void* malloc(IndexType)` and `void free(void*)`