### PR TITLE
[spirv] Add binary logical operations.

### DIFF
--- a/include/mlir/Dialect/SPIRV/SPIRVBase.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVBase.td
@@ -113,6 +113,16 @@ def SPV_OC_OpSRem              : I32EnumAttrCase<"OpSRem", 138>;
 def SPV_OC_OpSMod              : I32EnumAttrCase<"OpSMod", 139>;
 def SPV_OC_OpFRem              : I32EnumAttrCase<"OpFRem", 140>;
 def SPV_OC_OpFMod              : I32EnumAttrCase<"OpFMod", 141>;
+def SPV_OC_OpIEqual            : I32EnumAttrCase<"OpIEqual", 170>;
+def SPV_OC_OpINotEqual         : I32EnumAttrCase<"OpINotEqual", 171>;
+def SPV_OC_OpUGreaterThan      : I32EnumAttrCase<"OpUGreaterThan", 172>;
+def SPV_OC_OpSGreaterThan      : I32EnumAttrCase<"OpSGreaterThan", 173>;
+def SPV_OC_OpUGreaterThanEqual : I32EnumAttrCase<"OpUGreaterThanEqual", 174>;
+def SPV_OC_OpSGreaterThanEqual : I32EnumAttrCase<"OpSGreaterThanEqual", 175>;
+def SPV_OC_OpULessThan         : I32EnumAttrCase<"OpULessThan", 176>;
+def SPV_OC_OpSLessThan         : I32EnumAttrCase<"OpSLessThan", 177>;
+def SPV_OC_OpULessThanEqual    : I32EnumAttrCase<"OpULessThanEqual", 178>;
+def SPV_OC_OpSLessThanEqual    : I32EnumAttrCase<"OpSLessThanEqual", 179>;
 def SPV_OC_OpReturn            : I32EnumAttrCase<"OpReturn", 253>;
 
 def SPV_OpcodeAttr :
@@ -127,7 +137,11 @@ def SPV_OpcodeAttr :
       SPV_OC_OpAccessChain, SPV_OC_OpDecorate, SPV_OC_OpCompositeExtract,
       SPV_OC_OpIAdd, SPV_OC_OpFAdd, SPV_OC_OpISub, SPV_OC_OpFSub, SPV_OC_OpIMul,
       SPV_OC_OpFMul, SPV_OC_OpUDiv, SPV_OC_OpSDiv, SPV_OC_OpFDiv, SPV_OC_OpUMod,
-      SPV_OC_OpSRem, SPV_OC_OpSMod, SPV_OC_OpFRem, SPV_OC_OpFMod, SPV_OC_OpReturn
+      SPV_OC_OpSRem, SPV_OC_OpSMod, SPV_OC_OpFRem, SPV_OC_OpFMod, SPV_OC_OpIEqual,
+      SPV_OC_OpINotEqual, SPV_OC_OpUGreaterThan, SPV_OC_OpSGreaterThan,
+      SPV_OC_OpUGreaterThanEqual, SPV_OC_OpSGreaterThanEqual,
+      SPV_OC_OpULessThan, SPV_OC_OpSLessThan, SPV_OC_OpULessThanEqual,
+      SPV_OC_OpSLessThanEqual, SPV_OC_OpReturn
       ]> {
     let returnType = "::mlir::spirv::Opcode";
     let convertFromStorage = "static_cast<::mlir::spirv::Opcode>($_self.getInt())";
@@ -683,21 +697,39 @@ class SPV_Op<string mnemonic, list<OpTrait> traits = []> :
   bit autogenSerialization = 1;
 }
 
-class SPV_ArithmeticOp<string mnemonic, Type type,
-                       list<OpTrait> traits = []> :
-      SPV_Op<mnemonic,
-             !listconcat(traits, [NoSideEffect, SameOperandsAndResultType])> {
+class SPV_BinaryOp<string mnemonic, Type resultType, Type operandsType,
+                   list<OpTrait> traits = []> :
+      SPV_Op<mnemonic, traits> {
   let arguments = (ins
-    SPV_ScalarOrVectorOf<type>:$operand1,
-    SPV_ScalarOrVectorOf<type>:$operand2
+    SPV_ScalarOrVectorOf<operandsType>:$operand1,
+    SPV_ScalarOrVectorOf<operandsType>:$operand2
   );
   let results = (outs
-    SPV_ScalarOrVectorOf<type>:$result
+    SPV_ScalarOrVectorOf<resultType>:$result
   );
   let parser = [{ return impl::parseBinaryOp(parser, result); }];
   let printer = [{ return impl::printBinaryOp(getOperation(), p); }];
   // No additional verification needed in addition to the ODS-generated ones.
   let verifier = [{ return success(); }];
+}
+
+class SPV_ArithmeticOp<string mnemonic, Type type,
+                       list<OpTrait> traits = []> :
+      // Operands type same as result type.
+      SPV_BinaryOp<mnemonic, type, type,
+                   !listconcat(traits,
+                               [NoSideEffect, SameOperandsAndResultType])> {
+}
+
+class SPV_LogicalOp<string mnemonic, Type operandsType,
+                    list<OpTrait> traits = []> :
+      // Result type is SPV_Bool.
+      SPV_BinaryOp<mnemonic, SPV_Bool, operandsType,
+                   !listconcat(traits,
+                               [NoSideEffect, SameTypeOperands,
+                                SameOperandsAndResultShape])> {
+  let parser = [{ return ::parseBinaryLogicalOp(parser, result); }];
+  let printer = [{ return ::printBinaryLogicalOp(getOperation(), p); }];
 }
 
 

--- a/include/mlir/Dialect/SPIRV/SPIRVOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVOps.td
@@ -478,6 +478,68 @@ def SPV_IAddOp : SPV_ArithmeticOp<"IAdd", SPV_Integer, [Commutative]> {
 
 // -----
 
+def SPV_IEqualOp : SPV_LogicalOp<"IEqual", SPV_Integer, [Commutative]> {
+  let summary = "Integer comparison for equality.";
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    iequal-op ::= ssa-id `=` `spv.IEqual` ssa-use, ssa-use
+                             `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.IEqual %0, %1 : i32
+    %5 = spv.IEqual %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
+def SPV_INotEqualOp : SPV_LogicalOp<"INotEqual", SPV_Integer, [Commutative]> {
+  let summary = "Integer comparison for inequality.";
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    inot-equal-op ::= ssa-id `=` `spv.INotEqual` ssa-use, ssa-use
+                                 `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.INotEqual %0, %1 : i32
+    %5 = spv.INotEqual %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
 def SPV_IMulOp : SPV_ArithmeticOp<"IMul", SPV_Integer, [Commutative]> {
   let summary = "Integer multiplication of Operand 1 and Operand 2.";
 
@@ -656,6 +718,140 @@ def SPV_SDivOp : SPV_ArithmeticOp<"SDiv", SPV_Integer> {
 
 // -----
 
+def SPV_SGreaterThanOp : SPV_LogicalOp<"SGreaterThan", SPV_Integer, []> {
+  let summary = [{
+    Signed-integer comparison if Operand 1 is greater than  Operand 2.
+  }];
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    sgreater-than-op ::= ssa-id `=` `spv.SGreaterThan` ssa-use, ssa-use
+                                    `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.SGreaterThan %0, %1 : i32
+    %5 = spv.SGreaterThan %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
+def SPV_SGreaterThanEqualOp : SPV_LogicalOp<"SGreaterThanEqual", SPV_Integer, []> {
+  let summary = [{
+    Signed-integer comparison if Operand 1 is greater than or equal to
+    Operand 2.
+  }];
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    sgreater-than-equal-op ::= ssa-id `=` `spv.SGreaterThanEqual` ssa-use, ssa-use
+                                          `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.SGreaterThanEqual %0, %1 : i32
+    %5 = spv.SGreaterThanEqual %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
+def SPV_SLessThanOp : SPV_LogicalOp<"SLessThan", SPV_Integer, []> {
+  let summary = [{
+    Signed-integer comparison if Operand 1 is less than Operand 2.
+  }];
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    sless-than-op ::= ssa-id `=` `spv.SLessThan` ssa-use, ssa-use
+                                 `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.SLessThan %0, %1 : i32
+    %5 = spv.SLessThan %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
+def SPV_SLessThanEqualOp : SPV_LogicalOp<"SLessThanEqual", SPV_Integer, []> {
+  let summary = [{
+    Signed-integer comparison if Operand 1 is less than or equal to Operand
+    2.
+  }];
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    sless-than-equal-op ::= ssa-id `=` `spv.SLessThanEqual` ssa-use, ssa-use
+                                       `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.SLessThanEqual %0, %1 : i32
+    %5 = spv.SLessThanEqual %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
 def SPV_SModOp : SPV_ArithmeticOp<"SMod", SPV_Integer> {
   let summary = [{
     Signed remainder operation for the remainder whose sign matches the sign
@@ -797,6 +993,141 @@ def SPV_UDivOp : SPV_ArithmeticOp<"UDiv", SPV_Integer> {
     ```
     %4 = spv.UDiv %0, %1 : i32
     %5 = spv.UDiv %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
+def SPV_UGreaterThanOp : SPV_LogicalOp<"UGreaterThan", SPV_Integer, []> {
+  let summary = [{
+    Unsigned-integer comparison if Operand 1 is greater than  Operand 2.
+  }];
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    ugreater-than-op ::= ssa-id `=` `spv.UGreaterThan` ssa-use, ssa-use
+                                    `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.UGreaterhan %0, %1 : i32
+    %5 = spv.UGreaterThan %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
+def SPV_UGreaterThanEqualOp
+    : SPV_LogicalOp<"UGreaterThanEqual", SPV_Integer, []> {
+  let summary = [{
+    Unsigned-integer comparison if Operand 1 is greater than or equal to
+    Operand 2.
+  }];
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    ugreater-than-equal-op ::= ssa-id `=` `spv.UGreaterThanEqual` ssa-use, ssa-use
+                                          `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.UGreaterThanEqual %0, %1 : i32
+    %5 = spv.UGreaterThanEqual %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
+def SPV_ULessThanOp : SPV_LogicalOp<"ULessThan", SPV_Integer, []> {
+  let summary = [{
+    Unsigned-integer comparison if Operand 1 is less than Operand 2.
+  }];
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    uless-than-op ::= ssa-id `=` `spv.ULessThan` ssa-use, ssa-use
+                                 `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.ULessThan %0, %1 : i32
+    %5 = spv.ULessThan %2, %3 : vector<4xi32>
+
+    ```
+  }];
+}
+
+// -----
+
+def SPV_ULessThanEqualOp : SPV_LogicalOp<"ULessThanEqual", SPV_Integer, []> {
+  let summary = [{
+    Unsigned-integer comparison if Operand 1 is less than or equal to
+    Operand 2.
+  }];
+
+  let description = [{
+    Result Type must be a scalar or vector of Boolean type.
+
+     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    integer type.  They must have the same component width, and they must
+    have the same number of components as Result Type.
+
+     Results are computed per component.
+
+    ### Custom assembly form
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                 `vector<` integer-literal `x` integer-type `>`
+    uless-than-equal-op ::= ssa-id `=` `spv.ULessThanEqual` ssa-use, ssa-use
+                                       `:` integer-scalar-vector-type
+    ```
+    For example:
+
+    ```
+    %4 = spv.ULessThanEqual %0, %1 : i32
+    %5 = spv.ULessThanEqual %2, %3 : vector<4xi32>
 
     ```
   }];

--- a/test/Dialect/SPIRV/Serialization/bin_ops.mlir
+++ b/test/Dialect/SPIRV/Serialization/bin_ops.mlir
@@ -72,6 +72,56 @@ func @spirv_bin_ops() -> () {
       %0 = spv.SRem %arg0, %arg1 : vector<4xi32>
       spv.Return
     }
+    func @iequal_scalar(%arg0: i32, %arg1: i32)  {
+      // CHECK: {{.*}} = spv.IEqual {{.*}}, {{.*}} : i32
+      %0 = spv.IEqual %arg0, %arg1 : i32
+      spv.Return
+    }
+    func @inotequal_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+      // CHECK: {{.*}} = spv.INotEqual {{.*}}, {{.*}} : vector<4xi32>
+      %0 = spv.INotEqual %arg0, %arg1 : vector<4xi32>
+      spv.Return
+    }
+    func @sgt_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+      // CHECK: {{.*}} = spv.SGreaterThan {{.*}}, {{.*}} : vector<4xi32>
+      %0 = spv.SGreaterThan %arg0, %arg1 : vector<4xi32>
+      spv.Return
+    }
+    func @sge_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+      // CHECK: {{.*}} = spv.SGreaterThanEqual {{.*}}, {{.*}} : vector<4xi32>
+      %0 = spv.SGreaterThanEqual %arg0, %arg1 : vector<4xi32>
+      spv.Return
+    }
+    func @slt_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+      // CHECK: {{.*}} = spv.SLessThan {{.*}}, {{.*}} : vector<4xi32>
+      %0 = spv.SLessThan %arg0, %arg1 : vector<4xi32>
+      spv.Return
+    }
+    func @slte_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+      // CHECK: {{.*}} = spv.SLessThanEqual {{.*}}, {{.*}} : vector<4xi32>
+      %0 = spv.SLessThanEqual %arg0, %arg1 : vector<4xi32>
+      spv.Return
+    }
+    func @ugt_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+      // CHECK: {{.*}} = spv.UGreaterThan {{.*}}, {{.*}} : vector<4xi32>
+      %0 = spv.UGreaterThan %arg0, %arg1 : vector<4xi32>
+      spv.Return
+    }
+    func @ugte_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+      // CHECK: {{.*}} = spv.UGreaterThanEqual {{.*}}, {{.*}} : vector<4xi32>
+      %0 = spv.UGreaterThanEqual %arg0, %arg1 : vector<4xi32>
+      spv.Return
+    }
+    func @ult_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+      // CHECK: {{.*}} = spv.ULessThan {{.*}}, {{.*}} : vector<4xi32>
+      %0 = spv.ULessThan %arg0, %arg1 : vector<4xi32>
+      spv.Return
+    }
+    func @ulte_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>)  {
+     // CHECK: {{.*}} = spv.ULessThanEqual {{.*}}, {{.*}} : vector<4xi32>
+     %0 = spv.ULessThanEqual %arg0, %arg1 : vector<4xi32>
+     spv.Return
+   }
   }
   return
 }

--- a/test/Dialect/SPIRV/ops.mlir
+++ b/test/Dialect/SPIRV/ops.mlir
@@ -495,6 +495,38 @@ func @iadd_scalar(%arg: i32) -> i32 {
 // -----
 
 //===----------------------------------------------------------------------===//
+// spv.IEqual
+//===----------------------------------------------------------------------===//
+
+func @iequal_scalar(%arg0: i32, %arg1: i32) -> i1 {
+  // CHECK: {{.*}} = spv.IEqual {{.*}}, {{.*}} : i32
+  %0 = spv.IEqual %arg0, %arg1 : i32
+  return %0 : i1
+}
+
+// -----
+
+func @iequal_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.IEqual {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.IEqual %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.INotEqual
+//===----------------------------------------------------------------------===//
+
+func @inotequal_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.INotEqual {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.INotEqual %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // spv.IMul
 //===----------------------------------------------------------------------===//
 
@@ -672,6 +704,54 @@ func @sdiv_scalar(%arg: i32) -> i32 {
 // -----
 
 //===----------------------------------------------------------------------===//
+// spv.SGreaterThan
+//===----------------------------------------------------------------------===//
+
+func @sgt_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.SGreaterThan {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.SGreaterThan %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.SGreaterThanEqual
+//===----------------------------------------------------------------------===//
+
+func @sge_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.SGreaterThanEqual {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.SGreaterThanEqual %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.SLessThan
+//===----------------------------------------------------------------------===//
+
+func @slt_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.SLessThan {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.SLessThan %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.SLessThanEqual
+//===----------------------------------------------------------------------===//
+
+func @slte_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.SLessThanEqual {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.SLessThanEqual %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // spv.SMod
 //===----------------------------------------------------------------------===//
 
@@ -692,32 +772,6 @@ func @srem_scalar(%arg: i32) -> i32 {
   %0 = spv.SRem %arg, %arg : i32
   return %0 : i32
 }
-
-// -----
-
-//===----------------------------------------------------------------------===//
-// spv.UDiv
-//===----------------------------------------------------------------------===//
-
-func @udiv_scalar(%arg: i32) -> i32 {
-  // CHECK: spv.UDiv
-  %0 = spv.UDiv %arg, %arg : i32
-  return %0 : i32
-}
-
-// -----
-
-//===----------------------------------------------------------------------===//
-// spv.UMod
-//===----------------------------------------------------------------------===//
-
-func @umod_scalar(%arg: i32) -> i32 {
-  // CHECK: spv.UMod
-  %0 = spv.UMod %arg, %arg : i32
-  return %0 : i32
-}
-
-// -----
 
 //===----------------------------------------------------------------------===//
 // spv.StoreOp
@@ -825,6 +879,78 @@ func @aligned_store_incorrect_attributes(%arg0 : f32) -> () {
   // expected-error @+1 {{expected ']'}}
   spv.Store  "Function" %0, %arg0 ["Aligned", 4, 23] : f32
   return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.UDiv
+//===----------------------------------------------------------------------===//
+
+func @udiv_scalar(%arg: i32) -> i32 {
+  // CHECK: spv.UDiv
+  %0 = spv.UDiv %arg, %arg : i32
+  return %0 : i32
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.UGreaterThan
+//===----------------------------------------------------------------------===//
+
+func @ugt_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.UGreaterThan {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.UGreaterThan %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.UGreaterThanEqual
+//===----------------------------------------------------------------------===//
+
+func @ugte_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.UGreaterThanEqual {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.UGreaterThanEqual %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.ULessThan
+//===----------------------------------------------------------------------===//
+
+func @ult_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.ULessThan {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.ULessThan %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.ULessThanEqual
+//===----------------------------------------------------------------------===//
+
+func @ulte_vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> vector<4xi1> {
+  // CHECK: {{.*}} = spv.ULessThanEqual {{.*}}, {{.*}} : vector<4xi32>
+  %0 = spv.ULessThanEqual %arg0, %arg1 : vector<4xi32>
+  return %0 : vector<4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.UMod
+//===----------------------------------------------------------------------===//
+
+func @umod_scalar(%arg: i32) -> i32 {
+  // CHECK: spv.UMod
+  %0 = spv.UMod %arg, %arg : i32
+  return %0 : i32
 }
 
 // -----


### PR DESCRIPTION
This patch adds binary logical operations regarding to the spec section 3.32.15:
OpIEqual, OpINotEqual, OpUGreaterThan, OpSGreaterThan,
OpUGreaterThanEqual, OpSGreaterThanEqual, OpULessThan, OpSLessThan,
OpULessThanEqual, OpSLessThanEqual, this ops are useful for integer comparison.

I've splitted bianary ops to logical ops and arithmetic ops.
Also added custom parser, since default one does not fit the requirements (result type is different to operands type), and printer, verifier.

Tests added to ops.mlir and to  serialization test machinery.
Some tests related to arithmetic ops in ops.mlir reordered to the lexicographic order, since I was mistaken in previous commit.

@antiagainst @MaheshRavishankar can you please take a look?
Thanks.