### PR TITLE
Add the LLVM IR unreachable instruction to the LLVMIR dialect.

### DIFF
--- a/include/mlir/LLVMIR/LLVMOps.td
+++ b/include/mlir/LLVMIR/LLVMOps.td
@@ -301,14 +301,9 @@ def LLVM_ReturnOp : LLVM_TerminatorOp<"return", []> {
   let printer = [{ printReturnOp(p, *this); }];
 }
 def LLVM_UnreachableOp : LLVM_TerminatorOp<"unreachable", []> {
-  string llvmBuilder = [{
-    builder.CreateUnreachable();
-  }];
-  let verifier = [{
-    return success();
-  }];
-  let parser = [{ return parseUnreachableOp(parser, result); }];
-  let printer = [{ printUnreachableOp(p, *this); }];
+  string llvmBuilder = [{ builder.CreateUnreachable(); }];
+  let parser = [{ return success(); }];
+  let printer = [{ *p << getOperationName(); }];
 }
 
 // Pseudo-operations (do not appear in LLVM IR but necessary for the dialect to

--- a/include/mlir/LLVMIR/LLVMOps.td
+++ b/include/mlir/LLVMIR/LLVMOps.td
@@ -300,6 +300,16 @@ def LLVM_ReturnOp : LLVM_TerminatorOp<"return", []> {
   let parser = [{ return parseReturnOp(parser, result); }];
   let printer = [{ printReturnOp(p, *this); }];
 }
+def LLVM_UnreachableOp : LLVM_TerminatorOp<"unreachable", []> {
+  string llvmBuilder = [{
+    builder.CreateUnreachable();
+  }];
+  let verifier = [{
+    return success();
+  }];
+  let parser = [{ return parseUnreachableOp(parser, result); }];
+  let printer = [{ printUnreachableOp(p, *this); }];
+}
 
 // Pseudo-operations (do not appear in LLVM IR but necessary for the dialect to
 // work correctly).

--- a/lib/LLVMIR/IR/LLVMDialect.cpp
+++ b/lib/LLVMIR/IR/LLVMDialect.cpp
@@ -635,10 +635,6 @@ static void printReturnOp(OpAsmPrinter *p, ReturnOp &op) {
   *p << ' ' << *op.getOperand(0) << " : " << op.getOperand(0)->getType();
 }
 
-static void printUnreachableOp(OpAsmPrinter *p, UnreachableOp &op) {
-  *p << op.getOperationName() << " : () -> ()";
-}
-
 // <operation> ::= `llvm.return` ssa-use-list attribute-dict? `:`
 //                 type-list-no-parens
 static ParseResult parseReturnOp(OpAsmParser *parser, OperationState *result) {
@@ -655,15 +651,6 @@ static ParseResult parseReturnOp(OpAsmParser *parser, OperationState *result) {
       parser->resolveOperand(operands[0], type, result->operands))
     return failure();
   return success();
-}
-
-// <operation> ::= `llvm.unreachable` `:` type-list-no-parens
-static ParseResult parseUnreachableOp(OpAsmParser *parser,
-                                      OperationState *result) {
-  Type type;
-  if (parser->parseColonType(type))
-    return success();
-  return failure();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/LLVMIR/IR/LLVMDialect.cpp
+++ b/lib/LLVMIR/IR/LLVMDialect.cpp
@@ -635,6 +635,10 @@ static void printReturnOp(OpAsmPrinter *p, ReturnOp &op) {
   *p << ' ' << *op.getOperand(0) << " : " << op.getOperand(0)->getType();
 }
 
+static void printUnreachableOp(OpAsmPrinter *p, UnreachableOp &op) {
+  *p << op.getOperationName() << " : () -> ()";
+}
+
 // <operation> ::= `llvm.return` ssa-use-list attribute-dict? `:`
 //                 type-list-no-parens
 static ParseResult parseReturnOp(OpAsmParser *parser, OperationState *result) {
@@ -651,6 +655,15 @@ static ParseResult parseReturnOp(OpAsmParser *parser, OperationState *result) {
       parser->resolveOperand(operands[0], type, result->operands))
     return failure();
   return success();
+}
+
+// <operation> ::= `llvm.unreachable` `:` type-list-no-parens
+static ParseResult parseUnreachableOp(OpAsmParser *parser,
+                                      OperationState *result) {
+  Type type;
+  if (parser->parseColonType(type))
+    return success();
+  return failure();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Target/llvmir.mlir
+++ b/test/Target/llvmir.mlir
@@ -825,9 +825,7 @@ func @stringconstant() -> !llvm<"i8*"> {
   llvm.return %1 : !llvm<"i8*">
 }
 
-// CHECK-LABEL: define void @noreach() {
-// CHECK-NEXT:    unreachable
-// CHECK-NEXT:  }
 func @noreach() {
+// CHECK:    unreachable
   llvm.unreachable
 }

--- a/test/Target/llvmir.mlir
+++ b/test/Target/llvmir.mlir
@@ -825,3 +825,9 @@ func @stringconstant() -> !llvm<"i8*"> {
   llvm.return %1 : !llvm<"i8*">
 }
 
+// CHECK-LABEL: define void @noreach() {
+// CHECK-NEXT:    unreachable
+// CHECK-NEXT:  }
+func @noreach() {
+  llvm.unreachable
+}


### PR DESCRIPTION
http://llvm.org/docs/LangRef.html#unreachable-instruction

This instruction will be to support (otherwise regular) calls to the Flang
runtime that are known to never return to the caller.