### PR TITLE
[mlir-translate] Fix test suite.

### DIFF
--- a/test/Target/llvmir.mlir
+++ b/test/Target/llvmir.mlir
@@ -94,7 +94,7 @@ func @body_args(!llvm.i64) -> !llvm.i64
 // CHECK-LABEL: declare i32 @other(i64, i32)
 func @other(!llvm.i64, !llvm.i32) -> !llvm.i32
 
-// CHECK-LABEL: define i32 @func_args(i32, i32) {
+// CHECK-LABEL: define i32 @func_args(i32 {{%.*}}, i32 {{%.*}}) {
 // CHECK-NEXT: br label %[[ARGS_bb1:[0-9]+]]
 func @func_args(%arg0: !llvm.i32, %arg1: !llvm.i32) -> !llvm.i32 {
   %0 = llvm.constant(0 : i32) : !llvm.i32
@@ -406,7 +406,7 @@ func @store_load_static() {
   llvm.return
 }
 
-// CHECK-LABEL: define void @store_load_dynamic(i64)
+// CHECK-LABEL: define void @store_load_dynamic(i64 {{%.*}})
 func @store_load_dynamic(%arg0: !llvm.i64) {
 // CHECK-NEXT: %{{[0-9]+}} = mul i64 %{{[0-9]+}}, 4
 // CHECK-NEXT: %{{[0-9]+}} = call i8* @malloc(i64 %{{[0-9]+}})
@@ -476,7 +476,7 @@ func @store_load_dynamic(%arg0: !llvm.i64) {
   llvm.return
 }
 
-// CHECK-LABEL: define void @store_load_mixed(i64)
+// CHECK-LABEL: define void @store_load_mixed(i64 {{%.*}})
 func @store_load_mixed(%arg0: !llvm.i64) {
   %0 = llvm.constant(10 : index) : !llvm.i64
 // CHECK-NEXT: %{{[0-9]+}} = mul i64 2, %{{[0-9]+}}
@@ -561,7 +561,7 @@ func @store_load_mixed(%arg0: !llvm.i64) {
   llvm.return
 }
 
-// CHECK-LABEL: define { float*, i64 } @memref_args_rets({ float* }, { float*, i64 }, { float*, i64 }) {
+// CHECK-LABEL: define { float*, i64 } @memref_args_rets({ float* } {{%.*}}, { float*, i64 } {{%.*}}, { float*, i64 } {{%.*}}) {
 func @memref_args_rets(%arg0: !llvm<"{ float* }">, %arg1: !llvm<"{ float*, i64 }">, %arg2: !llvm<"{ float*, i64 }">) -> !llvm<"{ float*, i64 }"> {
   %0 = llvm.constant(7 : index) : !llvm.i64
 // CHECK-NEXT: %{{[0-9]+}} = call i64 @get_index()
@@ -615,7 +615,7 @@ func @memref_args_rets(%arg0: !llvm<"{ float* }">, %arg1: !llvm<"{ float*, i64 }
 }
 
 
-// CHECK-LABEL: define i64 @memref_dim({ float*, i64, i64 })
+// CHECK-LABEL: define i64 @memref_dim({ float*, i64, i64 } {{%.*}})
 func @memref_dim(%arg0: !llvm<"{ float*, i64, i64 }">) -> !llvm.i64 {
 // Expecting this to create an LLVM constant.
   %0 = llvm.constant(42 : index) : !llvm.i64
@@ -692,7 +692,7 @@ func @multireturn_caller() {
   llvm.return
 }
 
-// CHECK-LABEL: define <4 x float> @vector_ops(<4 x float>, <4 x i1>, <4 x i64>) {
+// CHECK-LABEL: define <4 x float> @vector_ops(<4 x float> {{%.*}}, <4 x i1> {{%.*}}, <4 x i64> {{%.*}}) {
 func @vector_ops(%arg0: !llvm<"<4 x float>">, %arg1: !llvm<"<4 x i1>">, %arg2: !llvm<"<4 x i64>">) -> !llvm<"<4 x float>"> {
   %0 = llvm.constant(dense<4.200000e+01> : vector<4xf32>) : !llvm<"<4 x float>">
 // CHECK-NEXT: %4 = fadd <4 x float> %0, <float 4.200000e+01, float 4.200000e+01, float 4.200000e+01, float 4.200000e+01>
@@ -763,7 +763,7 @@ func @ops(%arg0: !llvm.float, %arg1: !llvm.float, %arg2: !llvm.i32, %arg3: !llvm
 // Indirect function calls
 //
 
-// CHECK-LABEL: define void @indirect_const_call(i64) {
+// CHECK-LABEL: define void @indirect_const_call(i64 {{%.*}}) {
 func @indirect_const_call(%arg0: !llvm.i64) {
 // CHECK-NEXT:  call void @body(i64 %0)
   %0 = llvm.constant(@body) : !llvm<"void (i64)*">
@@ -772,7 +772,7 @@ func @indirect_const_call(%arg0: !llvm.i64) {
   llvm.return
 }
 
-// CHECK-LABEL: define i32 @indirect_call(i32 (float)*, float) {
+// CHECK-LABEL: define i32 @indirect_call(i32 (float)* {{%.*}}, float {{%.*}}) {
 func @indirect_call(%arg0: !llvm<"i32 (float)*">, %arg1: !llvm.float) -> !llvm.i32 {
 // CHECK-NEXT:  %3 = call i32 %0(float %1)
   %0 = llvm.call %arg0(%arg1) : (!llvm.float) -> !llvm.i32
@@ -785,7 +785,7 @@ func @indirect_call(%arg0: !llvm<"i32 (float)*">, %arg1: !llvm.float) -> !llvm.i
 // predecessor more than once.
 //
 
-// CHECK-LABEL: define void @cond_br_arguments(i1, i1) {
+// CHECK-LABEL: define void @cond_br_arguments(i1 {{%.*}}, i1 {{%.*}}) {
 func @cond_br_arguments(%arg0: !llvm.i1, %arg1: !llvm.i1) {
 // CHECK-NEXT:   br i1 %0, label %3, label %5
   llvm.cond_br %arg0, ^bb1(%arg0 : !llvm.i1), ^bb2
@@ -802,7 +802,7 @@ func @cond_br_arguments(%arg0: !llvm.i1, %arg1: !llvm.i1) {
   llvm.br ^bb1(%arg1 : !llvm.i1)
 }
 
-// CHECK-LABEL: define void @llvm_noalias(float* noalias) {
+// CHECK-LABEL: define void @llvm_noalias(float* noalias {{%*.}}) {
 func @llvm_noalias(%arg0: !llvm<"float*"> {llvm.noalias = true}) {
   llvm.return
 }


### PR DESCRIPTION
Hello, llvm ir printer was changed at LLVM r367755. https://reviews.llvm.org/rGa009a60a917bc30940422bcef73f8270566d78db
So, it prints value numbers for unnamed functions argument.
This patch provides simple fix for test suite.
@antiagainst can you please take a look?
Thanks.


