### PR TITLE
Add unreachable to avoid GCC -Wreturn-type warning

### DIFF
--- a/lib/TableGen/Pattern.cpp
+++ b/lib/TableGen/Pattern.cpp
@@ -193,6 +193,7 @@ int tblgen::SymbolInfoMap::SymbolInfo::getStaticValueCount() const {
   case Kind::Result:
     return op->getNumResults();
   }
+  llvm_unreachable("unknown kind");
 }
 
 std::string
@@ -212,6 +213,7 @@ tblgen::SymbolInfoMap::SymbolInfo::getVarDecl(StringRef name) const {
     return formatv("{0} {1};\n", op->getQualCppClassName(), name);
   }
   }
+  llvm_unreachable("unknown kind");
 }
 
 std::string
@@ -243,6 +245,7 @@ tblgen::SymbolInfoMap::SymbolInfo::getValueAndRangeUse(StringRef name,
     return name;
   }
   }
+  llvm_unreachable("unknown kind");
 }
 
 bool tblgen::SymbolInfoMap::bindOpArgument(StringRef symbol, const Operator &op,


### PR DESCRIPTION
GCC warns of control reaching end of non-void function (-Wreturn-type).