### PR TITLE
Fix AffineExpr::simplifyAdd bug

### DIFF
--- a/lib/IR/AffineExpr.cpp
+++ b/lib/IR/AffineExpr.cpp
@@ -341,7 +341,7 @@ static AffineExpr simplifyAdd(AffineExpr lhs, AffineExpr rhs) {
 
   // Process lrhs, which is 'expr floordiv c'.
   AffineBinaryOpExpr lrBinOpExpr = lrhs.dyn_cast<AffineBinaryOpExpr>();
-  if (!lrBinOpExpr)
+  if (!lrBinOpExpr || lrBinOpExpr.getKind() != AffineExprKind::FloorDiv)
     return nullptr;
 
   auto llrhs = lrBinOpExpr.getLHS();

--- a/test/IR/affine-map.mlir
+++ b/test/IR/affine-map.mlir
@@ -171,6 +171,9 @@
 // CHECK: #map{{[0-9]+}} = (d0) -> (d0 * 16 - (d0 + 1) + 15)
 #map52 = (d0) -> (16*d0 + ((d0 + 1) * -1) + 15)
 
+// CHECK: #map{{[0-9]+}} = (d0) -> (d0 - (d0 + 1))
+#map53 = (d0) -> (d0 - (d0 + 1))
+
 // Single identity maps are removed.
 // CHECK: func @f0(memref<2x4xi8, 1>)
 func @f0(memref<2x4xi8, #map0, 1>)
@@ -337,3 +340,6 @@ func @f51(memref<1xi8, #map51>)
 
 // CHECK: func @f52(memref<1xi8, #map{{[0-9]+}}>)
 func @f52(memref<1xi8, #map52>)
+
+// CHECK: func @f53(memref<1xi8, #map{{[0-9]+}}>)
+func @f53(memref<1xi8, #map53>)


### PR DESCRIPTION
- fix missing check while simplifying an expression with floordiv to a
  mod
- fixes issue #82

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>