### PR TITLE
Add vector memref support for mlir-cpu-runner func return

### DIFF
--- a/lib/Support/JitRunner.cpp
+++ b/lib/Support/JitRunner.cpp
@@ -141,6 +141,10 @@ static void printOneMemRef(Type t, void *val) {
   auto shape = memRefType.getShape();
   int64_t size = std::accumulate(shape.begin(), shape.end(), 1,
                                  std::multiplies<int64_t>());
+  if (auto vectorType = memRefType.getElementType().dyn_cast<VectorType>()) {
+    size *= vectorType.getNumElements();
+  }
+
   for (int64_t i = 0; i < size; ++i) {
     llvm::outs() << reinterpret_cast<StaticFloatMemRef *>(val)->data[i] << ' ';
   }


### PR DESCRIPTION
 - allow mlir-cpu-runner to execute functions that return memrefs with
   vector of f32 in addition to just those with f32.
    
 - align memref's being allocated from mlir-cpu-runner (for input/output
   args of entry point function) to memref element size boundaries.
    
Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>