### PR TITLE
Tweak to the parser to recognize that `->` is a special token that

### DIFF
--- a/lib/IR/AsmPrinter.cpp
+++ b/lib/IR/AsmPrinter.cpp
@@ -544,6 +544,12 @@ static bool isDialectSymbolSimpleEnoughForPrettyForm(StringRef symName) {
     case '{':
       nestedPunctuation.push_back(c);
       continue;
+    case '-':
+      if (symName.front() == '>') {
+	symName = symName.drop_front();
+	continue;
+      }
+      break;
     // Reject types with mismatched brackets.
     case '>':
       if (nestedPunctuation.pop_back_val() != '<')

--- a/lib/IR/AsmPrinter.cpp
+++ b/lib/IR/AsmPrinter.cpp
@@ -545,7 +545,7 @@ static bool isDialectSymbolSimpleEnoughForPrettyForm(StringRef symName) {
       nestedPunctuation.push_back(c);
       continue;
     case '-':
-      if (symName.front() == '>') {
+      if (!symName.empty() && symName.front() == '>') {
 	symName = symName.drop_front();
 	continue;
       }

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -379,6 +379,12 @@ ParseResult Parser::parsePrettyDialectSymbolName(StringRef &prettyName) {
       nestedPunctuation.push_back(c);
       continue;
 
+    case '-':
+      // the sequence `->` is treated as special token, not a match
+      if (*curPtr == '>')
+	++curPtr;
+      break;
+
     case '>':
       if (nestedPunctuation.pop_back_val() != '<')
         return emitError("unbalanced '>' character in pretty dialect name");

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -383,7 +383,7 @@ ParseResult Parser::parsePrettyDialectSymbolName(StringRef &prettyName) {
       // the sequence `->` is treated as special token, not a match
       if (*curPtr == '>')
 	++curPtr;
-      break;
+      continue;
 
     case '>':
       if (nestedPunctuation.pop_back_val() != '<')

--- a/test/IR/invalid.mlir
+++ b/test/IR/invalid.mlir
@@ -1156,3 +1156,5 @@ func @bool_literal_in_non_bool_tensor() {
   // expected-error @+1 {{expected i1 type for 'true' or 'false' values}}
   "foo"() {bar = dense<true> : tensor<2xi16>} : () -> ()
 }
+
+func @bad_arrow(%arg : !unreg.ptr<(i32)->) // expected-error {{unbalanced ')' character in pretty dialect name}}

--- a/test/IR/invalid.mlir
+++ b/test/IR/invalid.mlir
@@ -1157,4 +1157,5 @@ func @bool_literal_in_non_bool_tensor() {
   "foo"() {bar = dense<true> : tensor<2xi16>} : () -> ()
 }
 
-func @bad_arrow(%arg : !unreg.ptr<(i32)->) // expected-error {{unbalanced ')' character in pretty dialect name}}
+// expected-error @+1 {{unbalanced ')' character in pretty dialect name}}
+func @bad_arrow(%arg : !unreg.ptr<(i32)->)

--- a/test/IR/parser.mlir
+++ b/test/IR/parser.mlir
@@ -1077,3 +1077,5 @@ func @op_with_passthrough_region_args() {
   return
 }
 
+// CHECK-LABEL: func @ptr_to_function() -> !unreg<"ptr<() -> ()>">
+func @ptr_to_function() -> !unreg.ptr<() -> ()>

--- a/test/IR/parser.mlir
+++ b/test/IR/parser.mlir
@@ -1077,5 +1077,5 @@ func @op_with_passthrough_region_args() {
   return
 }
 
-// CHECK-LABEL: func @ptr_to_function() -> !unreg<"ptr<() -> ()>">
+// CHECK-LABEL: func @ptr_to_function() -> !unreg.ptr<() -> ()>
 func @ptr_to_function() -> !unreg.ptr<() -> ()>


### PR DESCRIPTION
shouldn't be split into two characters.  This change allows dialect
types to wrap function types as in `!my.ptr_type<(i32) -> i32>`.