### PR TITLE
Add missing lowering to CFG in mlir-cpu-runner + related cleanup

### DIFF
--- a/include/mlir/Conversion/ControlFlowToCFG/ConvertControlFlowToCFG.h
+++ b/include/mlir/Conversion/ControlFlowToCFG/ConvertControlFlowToCFG.h
@@ -39,7 +39,7 @@ void populateLoopToStdConversionPatterns(OwningRewritePatternList &patterns,
                                          MLIRContext *ctx);
 
 /// Creates a pass to convert loop.for, loop.if and loop.terminator ops to CFG.
-FunctionPassBase *createConvertToCFGPass();
+std::unique_ptr<FunctionPassBase> createLowerToCFGPass();
 
 } // namespace mlir
 

--- a/include/mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h
+++ b/include/mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h
@@ -58,14 +58,14 @@ void populateStdToLLVMConversionPatterns(LLVMTypeConverter &converter,
                                          OwningRewritePatternList &patterns);
 
 /// Creates a pass to convert the Standard dialect into the LLVMIR dialect.
-std::unique_ptr<ModulePassBase> createConvertToLLVMIRPass();
+std::unique_ptr<ModulePassBase> createLowerToLLVMPass();
 
 /// Creates a pass to convert operations to the LLVMIR dialect.  The conversion
 /// is defined by a list of patterns and a type converter that will be obtained
 /// during the pass using the provided callbacks.
 std::unique_ptr<ModulePassBase>
-createConvertToLLVMIRPass(LLVMPatternListFiller patternListFiller,
-                          LLVMTypeConverterMaker typeConverterMaker);
+createLowerToLLVMPass(LLVMPatternListFiller patternListFiller,
+                      LLVMTypeConverterMaker typeConverterMaker);
 
 /// Creates a pass to convert operations to the LLVMIR dialect.  The conversion
 /// is defined by a list of patterns obtained during the pass using the provided
@@ -73,8 +73,8 @@ createConvertToLLVMIRPass(LLVMPatternListFiller patternListFiller,
 /// during the pass.
 template <typename TypeConverter = LLVMTypeConverter>
 std::unique_ptr<ModulePassBase>
-createConvertToLLVMIRPass(LLVMPatternListFiller patternListFiller) {
-  return createConvertToLLVMIRPass(patternListFiller, [](MLIRContext *context) {
+createLowerToLLVMPass(LLVMPatternListFiller patternListFiller) {
+  return createLowerToLLVMPass(patternListFiller, [](MLIRContext *context) {
     return std::make_unique<TypeConverter>(context);
   });
 }

--- a/lib/Conversion/ControlFlowToCFG/ConvertControlFlowToCFG.cpp
+++ b/lib/Conversion/ControlFlowToCFG/ConvertControlFlowToCFG.cpp
@@ -270,8 +270,8 @@ void ControlFlowToCFGPass::runOnFunction() {
     signalPassFailure();
 }
 
-FunctionPassBase *mlir::createConvertToCFGPass() {
-  return new ControlFlowToCFGPass();
+std::unique_ptr<FunctionPassBase> mlir::createLowerToCFGPass() {
+  return std::make_unique<ControlFlowToCFGPass>();
 }
 
 static PassRegistration<ControlFlowToCFGPass>

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -1226,13 +1226,13 @@ struct LLVMLoweringPass : public ModulePass<LLVMLoweringPass> {
 };
 } // end namespace
 
-std::unique_ptr<ModulePassBase> mlir::createConvertToLLVMIRPass() {
+std::unique_ptr<ModulePassBase> mlir::createLowerToLLVMPass() {
   return std::make_unique<LLVMLoweringPass>();
 }
 
 std::unique_ptr<ModulePassBase>
-mlir::createConvertToLLVMIRPass(LLVMPatternListFiller patternListFiller,
-                                LLVMTypeConverterMaker typeConverterMaker) {
+mlir::createLowerToLLVMPass(LLVMPatternListFiller patternListFiller,
+                            LLVMTypeConverterMaker typeConverterMaker) {
   return std::make_unique<LLVMLoweringPass>(patternListFiller,
                                             typeConverterMaker);
 }

--- a/lib/Support/JitRunner.cpp
+++ b/lib/Support/JitRunner.cpp
@@ -25,6 +25,7 @@
 
 #include "mlir/Support/JitRunner.h"
 
+#include "mlir/Conversion/ControlFlowToCFG/ConvertControlFlowToCFG.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
@@ -172,7 +173,8 @@ static LogicalResult convertAffineStandardToLLVMIR(ModuleOp module) {
   manager.addPass(mlir::createCanonicalizerPass());
   manager.addPass(mlir::createCSEPass());
   manager.addPass(mlir::createLowerAffinePass());
-  manager.addPass(mlir::createConvertToLLVMIRPass());
+  manager.addPass(mlir::createLowerToCFGPass());
+  manager.addPass(mlir::createLowerToLLVMPass());
   return manager.run(module);
 }
 

--- a/test/mlir-cpu-runner/simple.mlir
+++ b/test/mlir-cpu-runner/simple.mlir
@@ -1,8 +1,7 @@
 // RUN: mlir-cpu-runner %s | FileCheck %s
 // RUN: mlir-cpu-runner -e foo -init-value 1000 %s | FileCheck -check-prefix=NOMAIN %s
 // RUN: mlir-cpu-runner %s -O3 | FileCheck %s
-// RUN: mlir-cpu-runner %s -O3 -loop-distribute -loop-vectorize | FileCheck %s
-// RUN: mlir-cpu-runner %s -loop-distribute -loop-vectorize | FileCheck %s
+// RUN: mlir-cpu-runner -e affine -init-value 2.0 %s | FileCheck -check-prefix=AFFINE %s
 
 // RUN: cp %s %t
 // RUN: mlir-cpu-runner %t -dump-object-file | FileCheck %t
@@ -40,3 +39,13 @@ func @foo(%a : memref<1x1xf32>) -> memref<1x1xf32> {
 }
 // NOMAIN: 2.234000e+03
 // NOMAIN-NEXT: 2.234000e+03
+
+func @affine(%a : memref<32xf32>) -> memref<32xf32> {
+  %cf1 = constant 42.0 : f32
+  %N = dim %a, 0 : memref<32xf32>
+  affine.for %i = 0 to %N {
+    affine.store %cf1, %a[%i] : memref<32xf32>
+  }
+  return %a : memref<32xf32>
+}
+// AFFINE: 4.2{{0+}}e+01

--- a/tools/mlir-cpu-runner/CMakeLists.txt
+++ b/tools/mlir-cpu-runner/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llvm_executable(mlir-cpu-runner
 )
 llvm_update_compile_flags(mlir-cpu-runner)
 whole_archive_link(mlir-cpu-runner
+  MLIRAffineOps
   MLIRLLVMIR
   MLIRStandardOps
   MLIRTargetLLVMIR


### PR DESCRIPTION
- the list of passes run by mlir-cpu-runner included -lower-affine and
  -lower-to-llvm but was missing -lower-to-cfg (because -lower-affine at
  some point used to lower straight to CFG); add -lower-to-cfg in
  between. IR with affine ops can now be run by mlir-cpu-runner.

- update -lower-to-cfg to be consistent with other passes (create*Pass methods
  were changed to return unique ptrs, but -lower-to-cfg appears to have been
  missed).

- mlir-cpu-runner was unable to parse custom form of affine op's - fix
  link options

- drop unnecessary run options from test/mlir-cpu-runner/simple.mlir
  (none of the test cases had loops)

- -convert-to-llvmir was changed to -lower-to-llvm at some point, but the
  create pass method name wasn't updated (this pass converts/lowers to LLVM
  dialect as opposed to LLVM IR). Fix this.

(If we prefer "convert", the cmd-line options could be changed to
"-convert-to-llvm/cfg" then.)

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>