### PR TITLE
Update CMakeLists.txt for shared library build

### DIFF
--- a/examples/Linalg/Linalg1/lib/CMakeLists.txt
+++ b/examples/Linalg/Linalg1/lib/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBS
   MLIRAnalysis
   MLIRControlFlowToCFG
   MLIREDSC
+  MLIRLinalg
   MLIRLLVMIR
   MLIRParser
   MLIRPass
@@ -26,13 +27,13 @@ set(LIBS
   MLIRTransforms
 )
 
-add_llvm_library(Linalg1LLVMConversion
+add_llvm_library(Linalg1LLVMConversion STATIC
   ConvertToLLVMDialect.cpp
   )
 target_link_libraries(Linalg1LLVMConversion PUBLIC MLIRLLVMIR
-  MLIRControlFlowToCFG MLIRStandardOps)
+  Linalg1 MLIRControlFlowToCFG MLIRStandardOps MLIRStandardToLLVM MLIRLinalg)
 
-add_llvm_library(Linalg1
+add_llvm_library(Linalg1 STATIC
   Analysis.cpp
   SliceOp.cpp
   ViewOp.cpp

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -16,5 +16,4 @@ add_llvm_library(MLIRAnalysis STATIC
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Analysis
   )
-add_dependencies(MLIRAnalysis MLIRAffineOps MLIRLoopOps)
-target_link_libraries(MLIRAnalysis MLIRAffineOps MLIRLoopOps)
+target_link_libraries(MLIRAnalysis MLIRAffineOps MLIRLoopOps MLIRPass)

--- a/lib/Conversion/GPUToNVVM/CMakeLists.txt
+++ b/lib/Conversion/GPUToNVVM/CMakeLists.txt
@@ -6,5 +6,7 @@ target_link_libraries(MLIRGPUtoNVVMTransforms
   MLIRGPU
   MLIRLLVMIR
   MLIRNVVMIR
+  MLIRStandardToLLVM
+  MLIRTransforms
   MLIRPass
   )

--- a/lib/Conversion/StandardToSPIRV/CMakeLists.txt
+++ b/lib/Conversion/StandardToSPIRV/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(MLIRSPIRVConversion
   MLIRPass
   MLIRSPIRV
   MLIRSupport
+  MLIRTransforms
   MLIRTransformUtils
   MLIRSPIRV
   MLIRStandardOps

--- a/lib/Conversion/VectorToLLVM/CMakeLists.txt
+++ b/lib/Conversion/VectorToLLVM/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_library(MLIRVectorToLLVM
 )
 set(LIBS
   MLIRLLVMIR
+  MLIRStandardToLLVM
   MLIRTransforms
   LLVMCore
   LLVMSupport

--- a/lib/Dialect/AffineOps/CMakeLists.txt
+++ b/lib/Dialect/AffineOps/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llvm_library(MLIRAffineOps
+add_llvm_library(MLIRAffineOps STATIC
   AffineOps.cpp
   DialectRegistration.cpp
 
@@ -7,4 +7,3 @@ add_llvm_library(MLIRAffineOps
   )
 add_dependencies(MLIRAffineOps MLIRAffineOpsIncGen MLIRIR MLIRStandardOps)
 target_link_libraries(MLIRAffineOps MLIRIR MLIRStandardOps)
-

--- a/lib/Dialect/FxpMathOps/CMakeLists.txt
+++ b/lib/Dialect/FxpMathOps/CMakeLists.txt
@@ -6,10 +6,13 @@ add_llvm_library(MLIRFxpMathOps
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/FxpMathOps
   )
-add_dependencies(MLIRFxpMathOps
-                 MLIRFxpMathOpsIncGen
-                 MLIRQuantOps
-                 MLIRIR
-                 MLIRPass
-                 MLIRSupport
-                 MLIRStandardOps)
+add_dependencies(
+  MLIRFxpMathOps
+  MLIRFxpMathOpsIncGen)
+target_link_libraries(
+  MLIRFxpMathOps
+  MLIRQuantOps
+  MLIRIR
+  MLIRPass
+  MLIRSupport
+  MLIRStandardOps)

--- a/lib/Dialect/GPU/CMakeLists.txt
+++ b/lib/Dialect/GPU/CMakeLists.txt
@@ -7,4 +7,4 @@ add_llvm_library(MLIRGPU
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/GPU
 )
 add_dependencies(MLIRGPU MLIRGPUOpsIncGen MLIRIR LLVMSupport)
-target_link_libraries(MLIRGPU MLIRIR MLIRStandardOps LLVMSupport)
+target_link_libraries(MLIRGPU MLIRIR MLIRPass MLIRStandardOps LLVMSupport)

--- a/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -5,7 +5,7 @@ add_llvm_library(MLIRLLVMIR
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/LLVMIR
   )
 add_dependencies(MLIRLLVMIR MLIRLLVMOpsIncGen MLIRLLVMConversionsIncGen LLVMAsmParser LLVMCore LLVMSupport)
-target_link_libraries(MLIRLLVMIR LLVMAsmParser LLVMCore LLVMSupport)
+target_link_libraries(MLIRLLVMIR MLIRIR LLVMAsmParser LLVMCore LLVMSupport)
 
 add_llvm_library(MLIRNVVMIR
   IR/NVVMDialect.cpp
@@ -14,4 +14,4 @@ add_llvm_library(MLIRNVVMIR
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/LLVMIR
   )
 add_dependencies(MLIRNVVMIR MLIRNVVMOpsIncGen MLIRNVVMConversionsIncGen LLVMAsmParser LLVMCore LLVMSupport)
-target_link_libraries(MLIRNVVMIR LLVMAsmParser LLVMCore LLVMSupport)
+target_link_libraries(MLIRNVVMIR MLIRLLVMIR MLIRIR LLVMAsmParser LLVMCore LLVMSupport)

--- a/lib/Dialect/Linalg/CMakeLists.txt
+++ b/lib/Dialect/Linalg/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llvm_library(MLIRLinalg
+add_llvm_library(MLIRLinalg STATIC
   LinalgRegistration.cpp
   Analysis/DependenceAnalysis.cpp
   IR/LinalgOps.cpp
@@ -17,8 +17,12 @@ add_llvm_library(MLIRLinalg
 
 add_dependencies(MLIRLinalg
 
-  MLIRAffineOps
   MLIRLinalgOpsIncGen
   MLIRLinalgLibraryOpsIncGen
+  )
+target_link_libraries(MLIRLinalg
+
+  MLIRAffineOps
+  MLIRIR
   MLIRStandardToLLVM
   )

--- a/lib/Dialect/LoopOps/CMakeLists.txt
+++ b/lib/Dialect/LoopOps/CMakeLists.txt
@@ -1,9 +1,9 @@
 file(GLOB globbed *.c *.cpp)
-add_llvm_library(MLIRLoopOps
+add_llvm_library(MLIRLoopOps STATIC
   ${globbed}
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/LoopOps
   )
-add_dependencies(MLIRLoopOps MLIRLoopOpsIncGen MLIRStandardOps LLVMSupport)
-target_link_libraries(MLIRLoopOps LLVMSupport)
+add_dependencies(MLIRLoopOps MLIRLoopOpsIncGen MLIRStandardOps MLIRIR LLVMSupport)
+target_link_libraries(MLIRLoopOps MLIRStandardOps MLIRIR LLVMSupport)

--- a/lib/Dialect/QuantOps/CMakeLists.txt
+++ b/lib/Dialect/QuantOps/CMakeLists.txt
@@ -19,3 +19,5 @@ add_dependencies(MLIRQuantOps
                  MLIRQuantOpsIncGen
                  MLIRSupport
                  MLIRStandardOps)
+
+target_link_libraries(MLIRQuantOps MLIRIR MLIRPass MLIRParser MLIRSupport MLIRTransforms MLIRAnalysis MLIRStandardOps LLVMSupport)

--- a/lib/Dialect/SPIRV/CMakeLists.txt
+++ b/lib/Dialect/SPIRV/CMakeLists.txt
@@ -16,6 +16,7 @@ add_dependencies(MLIRSPIRV
 target_link_libraries(MLIRSPIRV
   MLIRIR
   MLIRParser
-  MLIRSupport)
+  MLIRSupport
+  MLIRTranslation)
 
 add_subdirectory(Serialization)

--- a/lib/Dialect/SPIRV/Serialization/CMakeLists.txt
+++ b/lib/Dialect/SPIRV/Serialization/CMakeLists.txt
@@ -15,4 +15,5 @@ add_dependencies(MLIRSPIRVSerialization
 target_link_libraries(MLIRSPIRVSerialization
   MLIRIR
   MLIRSPIRV
-  MLIRSupport)
+  MLIRSupport
+  MLIRTranslation)

--- a/lib/Dialect/StandardOps/CMakeLists.txt
+++ b/lib/Dialect/StandardOps/CMakeLists.txt
@@ -1,9 +1,9 @@
 file(GLOB globbed *.c *.cpp)
-add_llvm_library(MLIRStandardOps
+add_llvm_library(MLIRStandardOps STATIC
   ${globbed}
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/StandardOps
   )
 add_dependencies(MLIRStandardOps MLIRStandardOpsIncGen LLVMSupport)
-target_link_libraries(MLIRStandardOps LLVMSupport)
+target_link_libraries(MLIRStandardOps MLIRIR MLIRParser LLVMSupport)

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -11,11 +11,19 @@ target_link_libraries(MLIRExecutionEngine
 
   MLIRLLVMIR
   MLIRTargetLLVMIR
+  Linalg1LLVMConversion
+  LLVMAggressiveInstCombine
+  LLVMAnalysis
   LLVMBitReader
   LLVMBitWriter
   LLVMExecutionEngine
+  LLVMInstCombine
   LLVMOrcJIT
+  LLVMMC
+  LLVMScalarOpts
   LLVMSupport
+  LLVMTarget
   LLVMTransformUtils
+  LLVMVectorize
 
   ${outlibs})

--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llvm_library(MLIRParser
+add_llvm_library(MLIRParser STATIC
   Lexer.cpp
   Parser.cpp
   Token.cpp

--- a/lib/Pass/CMakeLists.txt
+++ b/lib/Pass/CMakeLists.txt
@@ -1,9 +1,9 @@
 file(GLOB globbed *.c *.cpp)
-add_llvm_library(MLIRPass
+add_llvm_library(MLIRPass STATIC
   ${globbed}
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Pass
   )
-add_dependencies(MLIRPass MLIRAnalysis MLIRIR LLVMSupport)
+add_dependencies(MLIRPass MLIRIR LLVMSupport)
 target_link_libraries(MLIRPass MLIRAnalysis MLIRIR LLVMSupport)

--- a/lib/Quantizer/CMakeLists.txt
+++ b/lib/Quantizer/CMakeLists.txt
@@ -10,11 +10,12 @@ add_llvm_library(MLIRQuantizerSupport
 
   ADDITIONAL_HEADER_DIRS
   )
-add_dependencies(MLIRQuantizerSupport
-                 MLIRIR
-                 MLIRQuantOps
-                 MLIRSupport
-                 MLIRStandardOps)
+target_link_libraries(
+  MLIRQuantizerSupport
+  MLIRIR
+  MLIRQuantOps
+  MLIRSupport
+  MLIRStandardOps)
 
 # Configurations.
 add_llvm_library(MLIRQuantizerFxpMathConfig
@@ -22,9 +23,14 @@ add_llvm_library(MLIRQuantizerFxpMathConfig
 
   ADDITIONAL_HEADER_DIRS
   )
-add_dependencies(MLIRQuantizerFxpMathConfig
-                 MLIRFxpMathOpsIncGen
-                 MLIRQuantizerSupport)
+add_dependencies(
+  MLIRQuantizerFxpMathConfig
+  MLIRFxpMathOpsIncGen)
+target_link_libraries(
+  MLIRQuantizerFxpMathConfig
+  MLIRFxpMathOps
+  MLIRIR
+  MLIRQuantizerSupport)
 
 # Transforms.
 add_llvm_library(MLIRQuantizerTransforms

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -13,7 +13,7 @@ add_llvm_library(MLIRSupport
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Support
   )
-target_link_libraries(MLIRSupport LLVMSupport)
+target_link_libraries(MLIRSupport Threads::Threads LLVMSupport)
 
 add_llvm_library(MLIROptMain
   MlirOptMain.cpp
@@ -21,7 +21,7 @@ add_llvm_library(MLIROptMain
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Support
   )
-target_link_libraries(MLIROptMain LLVMSupport)
+target_link_libraries(MLIROptMain MLIRIR MLIRParser LLVMSupport)
 
 add_llvm_library(MLIRTranslateClParser
   TranslateClParser.cpp
@@ -29,7 +29,7 @@ add_llvm_library(MLIRTranslateClParser
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Support
   )
-target_link_libraries(MLIRTranslateClParser LLVMSupport)
+target_link_libraries(MLIRTranslateClParser MLIRTranslation MLIRIR MLIRAnalysis MLIRParser LLVMSupport)
 
 add_llvm_library(MLIRJitRunner
   JitRunner.cpp

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -31,6 +31,7 @@ add_dependencies(MLIRTransforms MLIRStandardOpsIncGen)
 target_link_libraries(MLIRTransforms
   MLIRAffineOps
   MLIRAnalysis
+  MLIREDSC
   MLIRLoopOps
   MLIRPass
   MLIRTransformUtils

--- a/test/lib/TestDialect/CMakeLists.txt
+++ b/test/lib/TestDialect/CMakeLists.txt
@@ -15,11 +15,11 @@ add_llvm_library(MLIRTestDialect
 )
 add_dependencies(MLIRTestDialect
   MLIRTestOpsIncGen
-  MLIRIR
-  LLVMSupport
 )
 target_link_libraries(MLIRTestDialect
   MLIRDialect
   MLIRIR
+  MLIRPass
+  MLIRTransforms
   LLVMSupport
 )

--- a/tools/mlir-opt/CMakeLists.txt
+++ b/tools/mlir-opt/CMakeLists.txt
@@ -3,17 +3,21 @@ set(LLVM_OPTIONAL_SOURCES
 )
 
 set(LIB_LIBS
+  Linalg1LLVMConversion
   MLIRAnalysis
+  MLIRIR
   MLIRLLVMIR
+  MLIROptMain
   MLIRParser
   MLIRPass
-  MLIRTransforms
+  MLIRQuantizerSupport
   MLIRSupport
+  MLIRTransforms
 )
 add_llvm_library(MLIRMlirOptLib
   mlir-opt.cpp
 )
-target_link_libraries(MLIRMlirOptLib ${LIB_LIBS})
+target_link_libraries(MLIRMlirOptLib ${LIB_LIBS} MLIRIR)
 
 set(LIBS
   MLIRAffineOps
@@ -40,7 +44,6 @@ set(LIBS
   MLIRStandardToLLVM
   MLIRTransforms
   MLIRTestDialect
-  MLIRTestPass
   MLIRTestTransforms
   MLIRSupport
   MLIRVectorOps


### PR DESCRIPTION
There are several circular dependencies between libraries.  These
are explicitly marked as STATIC.  Note that add_llvm_library is redundant
with add_dependencies, so we don't have to have libraries in both places.