### PR TITLE
[spirv] Add OpControlBarrier and OpMemoryBarrier

### DIFF
--- a/include/mlir/Dialect/SPIRV/SPIRVBase.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVBase.td
@@ -148,6 +148,8 @@ def SPV_OC_OpFOrdLessThanEqual      : I32EnumAttrCase<"OpFOrdLessThanEqual", 188
 def SPV_OC_OpFUnordLessThanEqual    : I32EnumAttrCase<"OpFUnordLessThanEqual", 189>;
 def SPV_OC_OpFOrdGreaterThanEqual   : I32EnumAttrCase<"OpFOrdGreaterThanEqual", 190>;
 def SPV_OC_OpFUnordGreaterThanEqual : I32EnumAttrCase<"OpFUnordGreaterThanEqual", 191>;
+def SPV_OC_OpControlBarrier         : I32EnumAttrCase<"OpControlBarrier", 224>;
+def SPV_OC_OpMemoryBarrier          : I32EnumAttrCase<"OpMemoryBarrier", 225>;
 def SPV_OC_OpLoopMerge              : I32EnumAttrCase<"OpLoopMerge", 246>;
 def SPV_OC_OpLabel                  : I32EnumAttrCase<"OpLabel", 248>;
 def SPV_OC_OpBranch                 : I32EnumAttrCase<"OpBranch", 249>;
@@ -180,8 +182,9 @@ def SPV_OpcodeAttr :
       SPV_OC_OpFUnordLessThan, SPV_OC_OpFOrdGreaterThan, SPV_OC_OpFUnordGreaterThan,
       SPV_OC_OpFOrdLessThanEqual, SPV_OC_OpFUnordLessThanEqual,
       SPV_OC_OpFOrdGreaterThanEqual, SPV_OC_OpFUnordGreaterThanEqual,
-      SPV_OC_OpLoopMerge, SPV_OC_OpLabel, SPV_OC_OpBranch,
-      SPV_OC_OpBranchConditional, SPV_OC_OpReturn, SPV_OC_OpReturnValue
+      SPV_OC_OpControlBarrier, SPV_OC_OpMemoryBarrier, SPV_OC_OpLoopMerge,
+      SPV_OC_OpLabel, SPV_OC_OpBranch, SPV_OC_OpBranchConditional, SPV_OC_OpReturn,
+      SPV_OC_OpReturnValue
       ]> {
     let returnType = "::mlir::spirv::Opcode";
     let convertFromStorage = "static_cast<::mlir::spirv::Opcode>($_self.getInt())";
@@ -1031,6 +1034,52 @@ def SPV_MemoryModelAttr :
     ]> {
   let returnType = "::mlir::spirv::MemoryModel";
   let convertFromStorage = "static_cast<::mlir::spirv::MemoryModel>($_self.getInt())";
+  let cppNamespace = "::mlir::spirv";
+}
+
+def SPV_MS_None                   : BitEnumAttrCase<"None", 0x0000>;
+def SPV_MS_Acquire                : BitEnumAttrCase<"Acquire", 0x0002>;
+def SPV_MS_Release                : BitEnumAttrCase<"Release", 0x0004>;
+def SPV_MS_AcquireRelease         : BitEnumAttrCase<"AcquireRelease", 0x0008>;
+def SPV_MS_SequentiallyConsistent : BitEnumAttrCase<"SequentiallyConsistent", 0x0010>;
+def SPV_MS_UniformMemory          : BitEnumAttrCase<"UniformMemory", 0x0040>;
+def SPV_MS_SubgroupMemory         : BitEnumAttrCase<"SubgroupMemory", 0x0080>;
+def SPV_MS_WorkgroupMemory        : BitEnumAttrCase<"WorkgroupMemory", 0x0100>;
+def SPV_MS_CrossWorkgroupMemory   : BitEnumAttrCase<"CrossWorkgroupMemory", 0x0200>;
+def SPV_MS_AtomicCounterMemory    : BitEnumAttrCase<"AtomicCounterMemory", 0x0400>;
+def SPV_MS_ImageMemory            : BitEnumAttrCase<"ImageMemory", 0x0800>;
+def SPV_MS_OutputMemory           : BitEnumAttrCase<"OutputMemory", 0x1000>;
+def SPV_MS_MakeAvailable          : BitEnumAttrCase<"MakeAvailable", 0x2000>;
+def SPV_MS_MakeVisible            : BitEnumAttrCase<"MakeVisible", 0x4000>;
+def SPV_MS_Volatile               : BitEnumAttrCase<"Volatile", 0x8000>;
+
+def SPV_MemorySemanticsAttr :
+    BitEnumAttr<"MemorySemantics", "valid SPIR-V MemorySemantics", [
+      SPV_MS_None, SPV_MS_Acquire, SPV_MS_Release, SPV_MS_AcquireRelease,
+      SPV_MS_SequentiallyConsistent, SPV_MS_UniformMemory, SPV_MS_SubgroupMemory,
+      SPV_MS_WorkgroupMemory, SPV_MS_CrossWorkgroupMemory,
+      SPV_MS_AtomicCounterMemory, SPV_MS_ImageMemory, SPV_MS_OutputMemory,
+      SPV_MS_MakeAvailable, SPV_MS_MakeVisible, SPV_MS_Volatile
+    ]> {
+  let returnType = "::mlir::spirv::MemorySemantics";
+  let convertFromStorage = "static_cast<::mlir::spirv::MemorySemantics>($_self.getInt())";
+  let cppNamespace = "::mlir::spirv";
+}
+
+def SPV_S_CrossDevice : I32EnumAttrCase<"CrossDevice", 0>;
+def SPV_S_Device      : I32EnumAttrCase<"Device", 1>;
+def SPV_S_Workgroup   : I32EnumAttrCase<"Workgroup", 2>;
+def SPV_S_Subgroup    : I32EnumAttrCase<"Subgroup", 3>;
+def SPV_S_Invocation  : I32EnumAttrCase<"Invocation", 4>;
+def SPV_S_QueueFamily : I32EnumAttrCase<"QueueFamily", 5>;
+
+def SPV_ScopeAttr :
+    I32EnumAttr<"Scope", "valid SPIR-V Scope", [
+      SPV_S_CrossDevice, SPV_S_Device, SPV_S_Workgroup, SPV_S_Subgroup,
+      SPV_S_Invocation, SPV_S_QueueFamily
+    ]> {
+  let returnType = "::mlir::spirv::Scope";
+  let convertFromStorage = "static_cast<::mlir::spirv::Scope>($_self.getInt())";
   let cppNamespace = "::mlir::spirv";
 }
 

--- a/include/mlir/Dialect/SPIRV/SPIRVOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVOps.td
@@ -172,6 +172,72 @@ def SPV_CompositeExtractOp : SPV_Op<"CompositeExtract", [NoSideEffect]> {
 
 // -----
 
+def SPV_ControlBarrierOp : SPV_Op<"ControlBarrier", []> {
+  let summary = [{
+    Wait for other invocations of this module to reach the current point of
+    execution.
+  }];
+
+  let description = [{
+    All invocations of this module within Execution scope must reach this
+    point of execution before any invocation will proceed beyond it.
+
+    When Execution is Workgroup or larger, behavior is undefined if this
+    instruction is used in control flow that is non-uniform within
+    Execution. When Execution is Subgroup or Invocation, the behavior of
+    this instruction in non-uniform control flow is defined by the client
+    API.
+
+    If Semantics is not None, this instruction also serves as an
+    OpMemoryBarrier instruction, and must also perform and adhere to the
+    description and semantics of an OpMemoryBarrier instruction with the
+    same Memory and Semantics operands.  This allows atomically specifying
+    both a control barrier and a memory barrier (that is, without needing
+    two instructions). If Semantics is None, Memory is ignored.
+
+    Before version 1.3, it is only valid to use this instruction with
+    TessellationControl, GLCompute, or Kernel execution models. There is no
+    such restriction starting with version 1.3.
+
+    When used with the TessellationControl execution model, it also
+    implicitly synchronizes the Output Storage Class:  Writes to Output
+    variables performed by any invocation executed prior to a
+    OpControlBarrier will be visible to any other invocation after return
+    from that OpControlBarrier.
+
+    ### Custom assembly form
+
+    ``` {.ebnf}
+    scope ::= `"CrossDevice"` | `"Device"` | `"Workgroup"` | ...
+
+    memory-semantics ::= `"None"` | `"Acquire"` | "Release"` | ...
+
+    control-barrier-op ::= `spv.ControlBarrier` scope, scope, memory-semantics
+    ```
+
+    For example:
+
+    ```
+    spv.ControlBarrier "Workgroup", "Device", "Acquire|UniformMemory"
+
+    ```
+  }];
+
+  let arguments = (ins
+    SPV_ScopeAttr:$execution_scope,
+    SPV_ScopeAttr:$memory_scope,
+    SPV_MemorySemanticsAttr:$memory_semantics
+  );
+
+  let results = (outs);
+
+  let verifier = [{ return verifyMemorySemantics(*this); }];
+
+  let autogenSerialization = 0;
+}
+
+// -----
+
 def SPV_ExecutionModeOp : SPV_Op<"ExecutionMode", [InModuleScope]> {
   let summary = "Declare an execution mode for an entry point.";
 
@@ -262,6 +328,53 @@ def SPV_LoadOp : SPV_Op<"Load", []> {
   let results = (outs
     SPV_Type:$value
   );
+}
+
+// -----
+
+def SPV_MemoryBarrierOp : SPV_Op<"MemoryBarrier", []> {
+  let summary = "Control the order that memory accesses are observed.";
+
+  let description = [{
+    Ensures that memory accesses issued before this instruction will be
+    observed before memory accesses issued after this instruction. This
+    control is ensured only for memory accesses issued by this invocation
+    and observed by another invocation executing within Memory scope.
+
+    Semantics declares what kind of memory is being controlled and what kind
+    of control to apply.
+
+    To execute both a memory barrier and a control barrier, see
+    OpControlBarrier.
+
+    ### Custom assembly form
+
+    ``` {.ebnf}
+    scope ::= `"CrossDevice"` | `"Device"` | `"Workgroup"` | ...
+
+    memory-semantics ::= `"None"` | `"Acquire"` | `"Release"` | ...
+
+    memory-barrier-op ::= `spv.MemoryBarrier` scope, memory-semantics
+    ```
+
+    For example:
+
+    ```
+    spv.MemoryBarrier "Device", "Acquire|UniformMemory"
+
+    ```
+  }];
+
+  let arguments = (ins
+    SPV_ScopeAttr:$memory_scope,
+    SPV_MemorySemanticsAttr:$memory_semantics
+  );
+
+  let results = (outs);
+
+  let verifier = [{ return verifyMemorySemantics(*this); }];
+
+  let autogenSerialization = 0;
 }
 
 // -----

--- a/lib/Dialect/SPIRV/Serialization/Deserializer.cpp
+++ b/lib/Dialect/SPIRV/Serialization/Deserializer.cpp
@@ -132,6 +132,11 @@ private:
   /// Gets the constant's attribute and type associated with the given <id>.
   Optional<std::pair<Attribute, Type>> getConstant(uint32_t id);
 
+  /// Gets the constants's integer attribute with the given <id>. Returns a null
+  /// IntegerAttr if the given is not registered or does not correspond to an
+  /// integer constant.
+  IntegerAttr getConstantInt(uint32_t id);
+
   /// Returns a symbol to be used for the function name with the given
   /// result <id>. This tries to use the function's OpName if
   /// exists; otherwise creates one based on the <id>.
@@ -895,6 +900,14 @@ LogicalResult Deserializer::processGlobalVariable(ArrayRef<uint32_t> operands) {
   }
   globalVariableMap[variableID] = varOp;
   return success();
+}
+
+IntegerAttr Deserializer::getConstantInt(uint32_t id) {
+  auto constInfo = getConstant(id);
+  if (!constInfo) {
+    return nullptr;
+  }
+  return constInfo->first.dyn_cast<IntegerAttr>();
 }
 
 LogicalResult Deserializer::processName(ArrayRef<uint32_t> operands) {
@@ -1886,6 +1899,32 @@ Deserializer::processOp<spirv::ExecutionModeOp>(ArrayRef<uint32_t> words) {
 
 template <>
 LogicalResult
+Deserializer::processOp<spirv::ControlBarrierOp>(ArrayRef<uint32_t> operands) {
+  if (operands.size() != 3) {
+    return emitError(
+        unknownLoc,
+        "OpControlBarrier must have execution scope <id>, memory scope <id> "
+        "and memory semantics <id>");
+  }
+
+  SmallVector<IntegerAttr, 3> argAttrs;
+  for (auto operand : operands) {
+    auto argAttr = getConstantInt(operand);
+    if (!argAttr) {
+      return emitError(unknownLoc,
+                       "expected 32-bit integer constant from <id> ")
+             << operand << " for OpControlBarrier";
+    }
+    argAttrs.push_back(argAttr);
+  }
+
+  opBuilder.create<spirv::ControlBarrierOp>(unknownLoc, argAttrs[0],
+                                            argAttrs[1], argAttrs[2]);
+  return success();
+}
+
+template <>
+LogicalResult
 Deserializer::processOp<spirv::FunctionCallOp>(ArrayRef<uint32_t> operands) {
   if (operands.size() < 3) {
     return emitError(unknownLoc,
@@ -1925,6 +1964,30 @@ Deserializer::processOp<spirv::FunctionCallOp>(ArrayRef<uint32_t> operands) {
   if (!resultTypes.empty()) {
     valueMap[resultID] = opFunctionCall.getResult(0);
   }
+  return success();
+}
+
+template <>
+LogicalResult
+Deserializer::processOp<spirv::MemoryBarrierOp>(ArrayRef<uint32_t> operands) {
+  if (operands.size() != 2) {
+    return emitError(unknownLoc, "OpMemoryBarrier must have memory scope <id> "
+                                 "and memory semantics <id>");
+  }
+
+  SmallVector<IntegerAttr, 2> argAttrs;
+  for (auto operand : operands) {
+    auto argAttr = getConstantInt(operand);
+    if (!argAttr) {
+      return emitError(unknownLoc,
+                       "expected 32-bit integer constant from <id> ")
+             << operand << " for OpMemoryBarrier";
+    }
+    argAttrs.push_back(argAttr);
+  }
+
+  opBuilder.create<spirv::MemoryBarrierOp>(unknownLoc, argAttrs[0],
+                                           argAttrs[1]);
   return success();
 }
 

--- a/lib/Dialect/SPIRV/Serialization/Serializer.cpp
+++ b/lib/Dialect/SPIRV/Serialization/Serializer.cpp
@@ -1510,6 +1510,26 @@ Serializer::processOp<spirv::EntryPointOp>(spirv::EntryPointOp op) {
 
 template <>
 LogicalResult
+Serializer::processOp<spirv::ControlBarrierOp>(spirv::ControlBarrierOp op) {
+  StringRef argNames[] = {"execution_scope", "memory_scope",
+                          "memory_semantics"};
+  SmallVector<uint32_t, 3> operands;
+
+  for (auto argName : argNames) {
+    auto argIntAttr = op.getAttrOfType<IntegerAttr>(argName);
+    auto operand = prepareConstantInt(op.getLoc(), argIntAttr);
+    if (!operand) {
+      return failure();
+    }
+    operands.push_back(operand);
+  }
+
+  return encodeInstructionInto(functions, spirv::Opcode::OpControlBarrier,
+                               operands);
+}
+
+template <>
+LogicalResult
 Serializer::processOp<spirv::ExecutionModeOp>(spirv::ExecutionModeOp op) {
   SmallVector<uint32_t, 4> operands;
   // Add the function <id>.
@@ -1533,6 +1553,25 @@ Serializer::processOp<spirv::ExecutionModeOp>(spirv::ExecutionModeOp op) {
     }
   }
   return encodeInstructionInto(executionModes, spirv::Opcode::OpExecutionMode,
+                               operands);
+}
+
+template <>
+LogicalResult
+Serializer::processOp<spirv::MemoryBarrierOp>(spirv::MemoryBarrierOp op) {
+  StringRef argNames[] = {"memory_scope", "memory_semantics"};
+  SmallVector<uint32_t, 2> operands;
+
+  for (auto argName : argNames) {
+    auto argIntAttr = op.getAttrOfType<IntegerAttr>(argName);
+    auto operand = prepareConstantInt(op.getLoc(), argIntAttr);
+    if (!operand) {
+      return failure();
+    }
+    operands.push_back(operand);
+  }
+
+  return encodeInstructionInto(functions, spirv::Opcode::OpMemoryBarrier,
                                operands);
 }
 

--- a/test/Dialect/SPIRV/Serialization/barrier.mlir
+++ b/test/Dialect/SPIRV/Serialization/barrier.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-translate -test-spirv-roundtrip %s | FileCheck %s
+
+spv.module "Logical" "GLSL450" {
+  func @memory_barrier_0() -> () {
+    // CHECK: spv.MemoryBarrier "Device", "Release|UniformMemory"
+    spv.MemoryBarrier "Device", "Release|UniformMemory"
+    spv.Return
+  }
+  func @memory_barrier_1() -> () {
+    // CHECK: spv.MemoryBarrier "Subgroup", "AcquireRelease|SubgroupMemory"
+    spv.MemoryBarrier "Subgroup", "AcquireRelease|SubgroupMemory"
+    spv.Return
+  }
+  func @control_barrier_0() -> () {
+    // CHECK: spv.ControlBarrier "Device", "Workgroup", "Release|UniformMemory"
+    spv.ControlBarrier "Device", "Workgroup", "Release|UniformMemory"
+    spv.Return
+  }
+  func @control_barrier_1() -> () {
+    // CHECK: spv.ControlBarrier "Workgroup", "Invocation", "AcquireRelease|UniformMemory"
+    spv.ControlBarrier "Workgroup", "Invocation", "AcquireRelease|UniformMemory"
+    spv.Return
+  }
+}

--- a/test/Dialect/SPIRV/ops.mlir
+++ b/test/Dialect/SPIRV/ops.mlir
@@ -263,6 +263,26 @@ func @composite_extract_result_type_mismatch(%arg0: !spv.array<4xf32>) -> i32 {
 // -----
 
 //===----------------------------------------------------------------------===//
+// spv.ControlBarrier
+//===----------------------------------------------------------------------===//
+
+func @control_barrier_0() -> () {
+  // CHECK:  spv.ControlBarrier "Workgroup", "Device", "Acquire|UniformMemory"
+  spv.ControlBarrier "Workgroup", "Device", "Acquire|UniformMemory"
+  return
+}
+
+// -----
+
+func @control_barrier_1() -> () {
+  // expected-error @+1 {{invalid scope attribute specification: "Something"}}
+  spv.ControlBarrier "Something", "Device", "Acquire|UniformMemory"
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // spv.ExecutionMode
 //===----------------------------------------------------------------------===//
 
@@ -498,6 +518,34 @@ spv.module "Logical" "GLSL450" {
     %1 = spv.Load "Input" %0 : f32
     spv.Return
   }
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.MemoryBarrier
+//===----------------------------------------------------------------------===//
+
+func @memory_barrier_0() -> () {
+  // CHECK: spv.MemoryBarrier "Device", "Acquire|UniformMemory"
+  spv.MemoryBarrier "Device", "Acquire|UniformMemory"
+  return
+}
+
+// -----
+
+func @memory_barrier_1() -> () {
+  // CHECK: spv.MemoryBarrier "Workgroup", "Acquire"
+  spv.MemoryBarrier "Workgroup", "Acquire"
+  return
+}
+
+// -----
+
+func @memory_barrier_2() -> () {
+ // expected-error @+1 {{expected at most one of these four memory constraints to be set: `Acquire`, `Release`,`AcquireRelease` or `SequentiallyConsistent`}}
+  spv.MemoryBarrier "Device", "Acquire|Release"
+  return
 }
 
 // -----

--- a/tools/mlir-tblgen/SPIRVUtilsGen.cpp
+++ b/tools/mlir-tblgen/SPIRVUtilsGen.cpp
@@ -703,6 +703,7 @@ static bool emitOpUtils(const RecordKeeper &recordKeeper, raw_ostream &os) {
 
 // Emits the following inline function for bit enums:
 // inline <enum-type> operator|(<enum-type> a, <enum-type> b);
+// inline <enum-type> operator&(<enum-type> a, <enum-type> b);
 // inline <enum-type> bitEnumContains(<enum-type> a, <enum-type> b);
 static void emitOperators(const Record &enumDef, raw_ostream &os) {
   EnumAttr enumAttr(enumDef);
@@ -711,6 +712,11 @@ static void emitOperators(const Record &enumDef, raw_ostream &os) {
   os << formatv("inline {0} operator|({0} lhs, {0} rhs) {{\n", enumName)
      << formatv("  return static_cast<{0}>("
                 "static_cast<{1}>(lhs) | static_cast<{1}>(rhs));\n",
+                enumName, underlyingType)
+     << "}\n";
+  os << formatv("inline {0} operator&({0} lhs, {0} rhs) {{\n", enumName)
+     << formatv("  return static_cast<{0}>("
+                "static_cast<{1}>(lhs) & static_cast<{1}>(rhs));\n",
                 enumName, underlyingType)
      << "}\n";
   os << formatv(


### PR DESCRIPTION
This patch addresses https://github.com/tensorflow/mlir/issues/127 

ebnf:
`scope ::=` `"CrossDevice"` | `"Device"` | `"Workgroup"` | `"Subgroup"`
              | `"Invocation"`

    memory-semantics ::= `"None"` | `"Acquire"` | `"Release"`
                         | `"AcquireReleae"` | `"SequentiallyConsistent"`
                         | `"UniformMemory"`  | `"SubgroupMemory"`
                         | `"WorkgroupMemory"`  | `"CrossWorkgroupMemory"`
                         | `"AtomicCounterMemory"` | `"ImageMemory"`

    control-barrier-op ::= `spv.ControlBarrier` scope, scope, memory-semantics

    memory-barrier-op ::= `spv.MemoryBarrier` scope, memory-semantics




Example:
``` 
 spv.ControlBarrier "Workgroup", "Device", "Acquire|UniformMemory"
 spv.MemoryBarrier "Device", "Acquire|UniformMemory"

```
@antiagainst @MaheshRavishankar can you please, take a look on this?
Thanks!