### PR TITLE
update normalizeMemRef utility; handle missing failure check + add mo…

### DIFF
--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -156,6 +156,12 @@ def AllocOp : Std_Op<"alloc"> {
 
   let extraClassDeclaration = [{
     MemRefType getType() { return getResult()->getType().cast<MemRefType>(); }
+
+    /// Returns the number of symbolic operands (the ones in square brackets),
+    /// which bind to the symbols of the memref's layout map.
+    unsigned getNumSymbolicOperands() {
+      return getNumOperands() - getType().getNumDynamicDims();
+    }
   }];
 
   let hasCanonicalizer = 1;


### PR DESCRIPTION
…re tests

- take care of symbolic operands with alloc
- add missing check for compose map failure and a test case
- add test cases on strides
- drop incorrect check for one-to-one'ness

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>