### PR TITLE
Add integer sign- and zero-extension and truncation to standard.

### DIFF
--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -821,7 +821,7 @@ def SelectOp : Std_Op<"select", [NoSideEffect, SameOperandsAndResultShape]> {
   let hasFolder = 1;
 }
 
-def SignExtendIOp : Std_Op<"sexti", [NoSideEffect]> {
+def SignExtendIOp : Std_Op<"sexti", [NoSideEffect, SameOperandsAndResultShape]> {
   let summary = "integer sign extension operation";
   let description = [{
     The integer sign extension operation takes an integer input of
@@ -990,7 +990,7 @@ def TensorStoreOp : Std_Op<"tensor_store",
   let verifier = ?;
 }
 
-def TruncateIOp : Std_Op<"trunci", [NoSideEffect]> {
+def TruncateIOp : Std_Op<"trunci", [NoSideEffect, SameOperandsAndResultShape]> {
   let summary = "integer truncation operation";
   let description = [{
     The integer truncation operation takes an integer input of
@@ -1031,7 +1031,7 @@ def XOrOp : IntArithmeticOp<"xor", [Commutative]> {
   let hasFolder = 1;
 }
 
-def ZeroExtendIOp : Std_Op<"zexti", [NoSideEffect]> {
+def ZeroExtendIOp : Std_Op<"zexti", [NoSideEffect, SameOperandsAndResultShape]> {
   let summary = "integer zero extension operation";
   let description = [{
     The integer zero extension operation takes an integer input of

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -820,6 +820,45 @@ def SelectOp : Std_Op<"select", [NoSideEffect, SameOperandsAndResultShape]> {
 
   let hasFolder = 1;
 }
+
+def SignExtendIOp : Std_Op<"sexti", [NoSideEffect]> {
+  let summary = "integer sign extension operation";
+  let description = [{
+    The integer sign extension operation takes an integer input of
+    width M and an integer destination type of width N. The destination
+    bit-width must be larger than the input bit-width (N > M).
+    The top-most (N - M) bits of the output are filled with copies
+    of the most-significant bit of the input.
+
+      %1 = constant 5 : i3            // %1 is 0b101
+      %2 = sexti %1 : i3 to i6        // %2 is 0b111101
+      %3 = constant 2 : i3            // %3 is 0b010
+      %4 = sexti %3 : i3 to i6        // %4 is 0b000010
+  }];
+
+  let arguments = (ins IntegerLike:$value);
+
+  let results = (outs IntegerLike);
+
+  let builders = [OpBuilder<
+    "Builder *builder, OperationState *result, Value *value, Type destType", [{
+      result->addOperands(value);
+      result->addTypes(destType);
+  }]>];
+
+  let extraClassDeclaration = [{
+    /// Returns the result type of the sign extension operation.
+    IntegerType getType() { return getResult()->getType().cast<IntegerType>(); }
+  }];
+
+  let parser = [{
+    return impl::parseCastOp(parser, result);
+  }];
+  let printer = [{
+    return printStandardCastOp(this->getOperation(), p);
+  }];
+}
+
 def ShlISOp : IntArithmeticOp<"shlis"> {
   let summary = "signed integer shift left";
 }
@@ -951,10 +990,82 @@ def TensorStoreOp : Std_Op<"tensor_store",
   let verifier = ?;
 }
 
+def TruncateIOp : Std_Op<"trunci", [NoSideEffect]> {
+  let summary = "integer truncation operation";
+  let description = [{
+    The integer truncation operation takes an integer input of
+    width M and an integer destination type of width N. The destination
+    bit-width must be smaller than the input bit-width (N < M).
+    The top-most (N - M) bits of the input are discareded.
+
+      %1 = constant 21 : i5           // %1 is 0b10101
+      %2 = trunci %1 : i5 to i4       // %2 is 0b0101
+      %3 = trunci %1 : i5 to i3       // %3 is 0b101
+  }];
+
+  let arguments = (ins IntegerLike:$value);
+
+  let results = (outs IntegerLike);
+
+  let builders = [OpBuilder<
+    "Builder *builder, OperationState *result, Value *value, Type destType", [{
+      result->addOperands(value);
+      result->addTypes(destType);
+  }]>];
+
+  let extraClassDeclaration = [{
+    /// Returns the result type of the truncation operation.
+    IntegerType getType() { return getResult()->getType().cast<IntegerType>(); }
+  }];
+
+  let parser = [{
+    return impl::parseCastOp(parser, result);
+  }];
+  let printer = [{
+    return printStandardCastOp(this->getOperation(), p);
+  }];
+}
 
 def XOrOp : IntArithmeticOp<"xor", [Commutative]> {
   let summary = "integer binary xor";
   let hasFolder = 1;
+}
+
+def ZeroExtendIOp : Std_Op<"zexti", [NoSideEffect]> {
+  let summary = "integer zero extension operation";
+  let description = [{
+    The integer zero extension operation takes an integer input of
+    width M and an integer destination type of width N. The destination
+    bit-width must be larger than the input bit-width (N > M).
+    The top-most (N - M) bits of the output are filled with zeros.
+
+      %1 = constant 5 : i3            // %1 is 0b101
+      %2 = zexti %1 : i3 to i6        // %2 is 0b000101
+      %3 = constant 2 : i3            // %3 is 0b010
+      %4 = zexti %3 : i3 to i6        // %4 is 0b000010
+  }];
+
+  let arguments = (ins IntegerLike:$value);
+
+  let results = (outs IntegerLike);
+
+  let builders = [OpBuilder<
+    "Builder *builder, OperationState *result, Value *value, Type destType", [{
+      result->addOperands(value);
+      result->addTypes(destType);
+  }]>];
+
+  let extraClassDeclaration = [{
+    /// Returns the result type of the zero extension operation.
+    IntegerType getType() { return getResult()->getType().cast<IntegerType>(); }
+  }];
+
+  let parser = [{
+    return impl::parseCastOp(parser, result);
+  }];
+  let printer = [{
+    return printStandardCastOp(this->getOperation(), p);
+  }];
 }
 
 #endif // STANDARD_OPS

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -834,6 +834,8 @@ def SignExtendIOp : Std_Op<"sexti", [NoSideEffect, SameOperandsAndResultShape]> 
       %2 = sexti %1 : i3 to i6        // %2 is 0b111101
       %3 = constant 2 : i3            // %3 is 0b010
       %4 = sexti %3 : i3 to i6        // %4 is 0b000010
+
+      %5 = sexti %0 : vector<2 x i32> to vector<2 x i64>
   }];
 
   let arguments = (ins IntegerLike:$value);
@@ -996,6 +998,8 @@ def TruncateIOp : Std_Op<"trunci", [NoSideEffect, SameOperandsAndResultShape]> {
       %1 = constant 21 : i5           // %1 is 0b10101
       %2 = trunci %1 : i5 to i4       // %2 is 0b0101
       %3 = trunci %1 : i5 to i3       // %3 is 0b101
+
+      %5 = trunci %0 : vector<2 x i32> to vector<2 x i16>
   }];
 
   let arguments = (ins IntegerLike:$value);
@@ -1033,6 +1037,8 @@ def ZeroExtendIOp : Std_Op<"zexti", [NoSideEffect, SameOperandsAndResultShape]> 
       %2 = zexti %1 : i3 to i6        // %2 is 0b000101
       %3 = constant 2 : i3            // %3 is 0b010
       %4 = zexti %3 : i3 to i6        // %4 is 0b000010
+
+      %5 = zexti %0 : vector<2 x i32> to vector<2 x i64>
   }];
 
   let arguments = (ins IntegerLike:$value);

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -846,11 +846,6 @@ def SignExtendIOp : Std_Op<"sexti", [NoSideEffect, SameOperandsAndResultShape]> 
       result->addTypes(destType);
   }]>];
 
-  let extraClassDeclaration = [{
-    /// Returns the result type of the sign extension operation.
-    IntegerType getType() { return getResult()->getType().cast<IntegerType>(); }
-  }];
-
   let parser = [{
     return impl::parseCastOp(parser, result);
   }];
@@ -1013,11 +1008,6 @@ def TruncateIOp : Std_Op<"trunci", [NoSideEffect, SameOperandsAndResultShape]> {
       result->addTypes(destType);
   }]>];
 
-  let extraClassDeclaration = [{
-    /// Returns the result type of the truncation operation.
-    IntegerType getType() { return getResult()->getType().cast<IntegerType>(); }
-  }];
-
   let parser = [{
     return impl::parseCastOp(parser, result);
   }];
@@ -1054,11 +1044,6 @@ def ZeroExtendIOp : Std_Op<"zexti", [NoSideEffect, SameOperandsAndResultShape]> 
       result->addOperands(value);
       result->addTypes(destType);
   }]>];
-
-  let extraClassDeclaration = [{
-    /// Returns the result type of the zero extension operation.
-    IntegerType getType() { return getResult()->getType().cast<IntegerType>(); }
-  }];
 
   let parser = [{
     return impl::parseCastOp(parser, result);

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -1008,6 +1008,21 @@ struct SIToFPLowering
   using Super::Super;
 };
 
+struct SignExtendIOpLowering
+    : public OneToOneLLVMOpLowering<SignExtendIOp, LLVM::SExtOp> {
+  using Super::Super;
+};
+
+struct TruncateIOpLowering
+    : public OneToOneLLVMOpLowering<TruncateIOp, LLVM::TruncOp> {
+  using Super::Super;
+};
+
+struct ZeroExtendIOpLowering
+    : public OneToOneLLVMOpLowering<ZeroExtendIOp, LLVM::ZExtOp> {
+  using Super::Super;
+};
+
 // Base class for LLVM IR lowering terminator operations with successors.
 template <typename SourceOp, typename TargetOp>
 struct OneToOneLLVMTerminatorLowering
@@ -1143,8 +1158,9 @@ void mlir::populateStdToLLVMConversionPatterns(
       DivFOpLowering, FuncOpConversion, IndexCastOpLowering, LoadOpLowering,
       MemRefCastOpLowering, MulFOpLowering, MulIOpLowering, OrOpLowering,
       RemISOpLowering, RemIUOpLowering, RemFOpLowering, ReturnOpLowering,
-      SelectOpLowering, SIToFPLowering, StoreOpLowering, SubFOpLowering,
-      SubIOpLowering, XOrOpLowering>(*converter.getDialect(), converter);
+      SelectOpLowering, SignExtendIOpLowering, SIToFPLowering, StoreOpLowering,
+      SubFOpLowering, SubIOpLowering, TruncateIOpLowering, XOrOpLowering,
+      ZeroExtendIOpLowering>(*converter.getDialect(), converter);
 }
 
 // Convert types using the stored LLVM IR module.

--- a/lib/Dialect/StandardOps/Ops.cpp
+++ b/lib/Dialect/StandardOps/Ops.cpp
@@ -2022,6 +2022,24 @@ OpFoldResult SelectOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// SignExtendIOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verify(SignExtendIOp op) {
+  auto opType = op.getOperand()->getType().dyn_cast_or_null<IntegerType>();
+  if (!opType)
+    return op.emitError("operand type ") << opType << " is not an integer ";
+  auto resType = op.getType().dyn_cast_or_null<IntegerType>();
+  if (!resType)
+    return op.emitError("result type ") << resType << " is not an integer ";
+  if (opType.getWidth() >= resType.getWidth())
+    return op.emitError("result type ")
+           << resType << " must be wider than operand type " << opType;
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // StoreOp
 //===----------------------------------------------------------------------===//
 
@@ -2241,6 +2259,42 @@ static ParseResult parseTensorStoreOp(OpAsmParser *parser,
       parser->resolveOperands(
           ops, {getTensorTypeFromMemRefType(parser->getBuilder(), type), type},
           loc, result->operands));
+}
+
+//===----------------------------------------------------------------------===//
+// TruncateIOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verify(TruncateIOp op) {
+  auto opType = op.getOperand()->getType().dyn_cast_or_null<IntegerType>();
+  if (!opType)
+    return op.emitError("operand type ") << opType << " is not an integer ";
+  auto resType = op.getType().dyn_cast_or_null<IntegerType>();
+  if (!resType)
+    return op.emitError("result type ") << resType << " is not an integer ";
+  if (opType.getWidth() <= resType.getWidth())
+    return op.emitError("operand type ")
+           << opType << " must be wider than result type " << resType;
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ZeroExtendIOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verify(ZeroExtendIOp op) {
+  auto opType = op.getOperand()->getType().dyn_cast_or_null<IntegerType>();
+  if (!opType)
+    return op.emitError("operand type ") << opType << " is not an integer ";
+  auto resType = op.getType().dyn_cast_or_null<IntegerType>();
+  if (!resType)
+    return op.emitError("result type ") << resType << " is not an integer ";
+  if (opType.getWidth() >= resType.getWidth())
+    return op.emitError("result type ")
+           << resType << " must be wider than operand type " << opType;
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
+++ b/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
@@ -443,6 +443,20 @@ func @sitofp(%arg0 : i32, %arg1 : i64) {
   return
 }
 
+// Check sign and zero extension and truncation of integers.
+// CHECK-LABEL: @integer_extension_and_truncation
+func @integer_extension_and_truncation() {
+// CHECK-NEXT:  %0 = llvm.mlir.constant(-3 : i3) : !llvm.i3
+  %0 = constant 5 : i3
+// CHECK-NEXT: = llvm.sext %0 : !llvm.i3 to !llvm.i6
+  %1 = sexti %0 : i3 to i6
+// CHECK-NEXT: = llvm.zext %0 : !llvm.i3 to !llvm.i6
+  %2 = zexti %0 : i3 to i6
+// CHECK-NEXT: = llvm.trunc %0 : !llvm.i3 to !llvm.i2
+   %3 = trunci %0 : i3 to i2
+  return
+}
+
 // CHECK-LABEL: @dfs_block_order
 func @dfs_block_order() -> (i32) {
 // CHECK-NEXT:  %0 = llvm.mlir.constant(42 : i32) : !llvm.i32

--- a/test/IR/core-ops.mlir
+++ b/test/IR/core-ops.mlir
@@ -315,17 +315,35 @@ func @standard_instrs(tensor<4x4x?xf32>, f32, i32, index, i64) {
   // CHECK: = sexti %arg2 : i32 to i64
   %83 = sexti %i : i32 to i64
 
-  // CHECK: = zexti %arg2 : i32 to i64
-  %84 = "std.zexti"(%i) : (i32) -> i64
+  // CHECK: %{{[0-9]+}} = sexti %cst_5 : vector<42xi32>
+  %84 = sexti %vci32 : vector<42 x i32> to vector<42 x i64>
+
+  // CHECK: %{{[0-9]+}} = sexti %cst_4 : tensor<42xi32>
+  %85 = sexti %tci32 : tensor<42 x i32> to tensor<42 x i64>
 
   // CHECK: = zexti %arg2 : i32 to i64
-  %85 = zexti %i : i32 to i64
+  %86 = "std.zexti"(%i) : (i32) -> i64
+
+  // CHECK: = zexti %arg2 : i32 to i64
+  %87 = zexti %i : i32 to i64
+
+  // CHECK: %{{[0-9]+}} = zexti %cst_5 : vector<42xi32>
+  %88 = zexti %vci32 : vector<42 x i32> to vector<42 x i64>
+
+  // CHECK: %{{[0-9]+}} = zexti %cst_4 : tensor<42xi32>
+  %89 = zexti %tci32 : tensor<42 x i32> to tensor<42 x i64>
 
   // CHECK: = trunci %arg2 : i32 to i16
-  %86 = "std.trunci"(%i) : (i32) -> i16
+  %90 = "std.trunci"(%i) : (i32) -> i16
 
   // CHECK: = trunci %arg2 : i32 to i16
-  %87 = trunci %i : i32 to i16
+  %91 = trunci %i : i32 to i16
+
+  // CHECK: %{{[0-9]+}} = trunci %cst_5 : vector<42xi32>
+  %92 = trunci %vci32 : vector<42 x i32> to vector<42 x i16>
+
+  // CHECK: %{{[0-9]+}} = trunci %cst_4 : tensor<42xi32>
+  %93 = trunci %tci32 : tensor<42 x i32> to tensor<42 x i16>
 
   return
 }

--- a/test/IR/core-ops.mlir
+++ b/test/IR/core-ops.mlir
@@ -309,6 +309,24 @@ func @standard_instrs(tensor<4x4x?xf32>, f32, i32, index, i64) {
   // CHECK: = sitofp {{.*}} : i64 to f64
   %81 = sitofp %j : i64 to f64
 
+  // CHECK: = sexti %arg2 : i32 to i64
+  %82 = "std.sexti"(%i) : (i32) -> i64
+
+  // CHECK: = sexti %arg2 : i32 to i64
+  %83 = sexti %i : i32 to i64
+
+  // CHECK: = zexti %arg2 : i32 to i64
+  %84 = "std.zexti"(%i) : (i32) -> i64
+
+  // CHECK: = zexti %arg2 : i32 to i64
+  %85 = zexti %i : i32 to i64
+
+  // CHECK: = trunci %arg2 : i32 to i16
+  %86 = "std.trunci"(%i) : (i32) -> i16
+
+  // CHECK: = trunci %arg2 : i32 to i16
+  %87 = trunci %i : i32 to i16
+
   return
 }
 

--- a/test/IR/invalid-ops.mlir
+++ b/test/IR/invalid-ops.mlir
@@ -718,6 +718,102 @@ func @sitofp_f32_to_i32(%arg0 : f32) {
 
 // -----
 
+func @sexti_index_as_operand(%arg0 : index) {
+  // expected-error@+1 {{'index' is not a valid operand type}}
+  %0 = sexti %arg0 : index to i128
+  return
+}
+
+// -----
+
+func @zexti_index_as_operand(%arg0 : index) {
+  // expected-error@+1 {{'index' is not a valid operand type}}
+  %0 = zexti %arg0 : index to i128
+  return
+}
+
+// -----
+
+func @trunci_index_as_operand(%arg0 : index) {
+  // expected-error@+1 {{'index' is not a valid operand type}}
+  %2 = trunci %arg0 : index to i128
+  return
+}
+
+// -----
+
+func @sexti_index_as_result(%arg0 : i1) {
+  // expected-error@+1 {{'index' is not a valid result type}}
+  %0 = sexti %arg0 : i1 to index
+  return
+}
+
+// -----
+
+func @zexti_index_as_operand(%arg0 : i1) {
+  // expected-error@+1 {{'index' is not a valid result type}}
+  %0 = zexti %arg0 : i1 to index
+  return
+}
+
+// -----
+
+func @trunci_index_as_result(%arg0 : i128) {
+  // expected-error@+1 {{'index' is not a valid result type}}
+  %2 = trunci %arg0 : i128 to index
+  return
+}
+
+// -----
+
+func @sexti_cast_to_narrower(%arg0 : i16) {
+  // expected-error@+1 {{must be wider}}
+  %0 = sexti %arg0 : i16 to i15
+  return
+}
+
+// -----
+
+func @zexti_cast_to_narrower(%arg0 : i16) {
+  // expected-error@+1 {{must be wider}}
+  %0 = zexti %arg0 : i16 to i15
+  return
+}
+
+// -----
+
+func @trunci_cast_to_wider(%arg0 : i16) {
+  // expected-error@+1 {{must be wider}}
+  %0 = trunci %arg0 : i16 to i17
+  return
+}
+
+// -----
+
+func @sexti_cast_to_same_width(%arg0 : i16) {
+  // expected-error@+1 {{must be wider}}
+  %0 = sexti %arg0 : i16 to i16
+  return
+}
+
+// -----
+
+func @zexti_cast_to_same_width(%arg0 : i16) {
+  // expected-error@+1 {{must be wider}}
+  %0 = zexti %arg0 : i16 to i16
+  return
+}
+
+// -----
+
+func @trunci_cast_to_same_width(%arg0 : i16) {
+  // expected-error@+1 {{must be wider}}
+  %0 = trunci %arg0 : i16 to i16
+  return
+}
+
+// -----
+
 func @return_not_in_function() {
   "foo.region"() ({
     // expected-error@+1 {{'std.return' op expects parent op 'func'}}

--- a/test/Target/llvmir.mlir
+++ b/test/Target/llvmir.mlir
@@ -935,3 +935,13 @@ func @fp_casts(%fp1 : !llvm<"float">, %fp2 : !llvm<"double">) -> !llvm.i16 {
   %c = llvm.fptosi %b : !llvm<"double"> to !llvm.i16
   llvm.return %c : !llvm.i16
 }
+
+func @integer_extension_and_truncation(%a : !llvm.i32) {
+// CHECK:    sext i32 {{.*}} to i64
+// CHECK:    zext i32 {{.*}} to i64
+// CHECK:    trunc i32 {{.*}} to i16
+  %0 = llvm.sext %a : !llvm.i32 to !llvm.i64
+  %1 = llvm.zext %a : !llvm.i32 to !llvm.i64
+  %2 = llvm.trunc %a : !llvm.i32 to !llvm.i16
+  llvm.return
+}


### PR DESCRIPTION
Currently sext, zext and trunc operations for integers are missing in the standard dialect.
If one wants to combine integers of different bit-widths, one has to use the LLVM operations
for extending/truncating and introduce custom casts to convert LLVM integer types to
standard types. Exposing sext, zext and trunc directly in the standard dialect allows to 
perfom integer conversions without this hassle.

Since this is my first addition to MLIR, I'd like some feedback for the implementation, especially:
- Naming of the operations and their memonics
- Are the tests sufficient as is or should I add more (if so, where)?
