### PR TITLE
Introduce splat op + provide its LLVM lowering

### DIFF
--- a/g3doc/Dialects/Standard.md
+++ b/g3doc/Dialects/Standard.md
@@ -352,6 +352,36 @@ because of the
 [restrictions on dimensions and symbols](Affine.md#restrictions-on-dimensions-and-symbols)
 in these contexts.
 
+### 'splat' operation
+
+Syntax:
+
+``` {.ebnf}
+operation ::= `splat` ssa-use `:` ( vector-type | tensor-type )
+```
+
+Broadcast the operand to all elements of the result vector or tensor. The
+operand has to be of either integer or float type. When the result is a
+tensor, it has to be statically shaped.
+
+Example:
+
+```mlir {.mlir}
+  %s = load %A[%i] : memref<128xf32>
+  %v = splat %s : vector<4xf32>
+  %t = splat %s : tensor<8x16xi32>
+```
+
+TODO: This operation is easy to extend to broadcast to dynamically shaped
+tensors in the same way dynamically shaped memrefs are handled.
+```mlir {.mlir}
+// Broadcasts %s to a 2-d dynamically shaped tensor, with %m, %n binding
+// to the sizes of the two dynamic dimensions.
+%m = "foo"() : () -> (index)
+%n = "bar"() : () -> (index)
+%t = splat %s [%m, %n] : tensor<?x?xi32>
+```
+
 ### 'store' operation
 
 Syntax:

--- a/g3doc/LangRef.md
+++ b/g3doc/LangRef.md
@@ -692,7 +692,7 @@ index-type ::= `index`
 
 The `index` type is a signless integer whose size is equal to the natural
 machine word of the target ([rationale](Rationale.md#signless-types)) and is
-used by the affine constructs in MLIR. Unlike fixed-size integers. It cannot be
+used by the affine constructs in MLIR. Unlike fixed-size integers, it cannot be
 used as an element of vector, tensor or memref type
 ([rationale](Rationale.md#index-type-disallowed-in-vectortensormemref-types)).
 

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -871,6 +871,33 @@ def ShlISOp : IntArithmeticOp<"shlis"> {
   let summary = "signed integer shift left";
 }
 
+def SplatOp : Std_Op<"splat", [NoSideEffect]> {
+  let summary = "splat or broadcast operation";
+  let description = [{
+    The "splat" op reads a value of integer or float type and broadcasts it into
+    a vector or a tensor. The output of splat is thus a new value of either
+    vector or tensor type with elemental type being its operand's type.
+    When the result is a tensor, it has to be statically shaped.
+
+      %1 = splat %0 : vector<8xi32>
+      %2 = splat %0 : tensor<4x8xi32>
+
+    // TODO: handle broadcast to dynamically shaped tensors.
+  }];
+
+  let arguments = (ins AnyTypeOf<[AnyInteger, AnyFloat],
+                                 "integer or float type">:$input);
+
+  let results = (outs AnyTypeOf<[AnyVector, AnyStaticShapeTensor]>:$aggregate);
+
+  let builders =
+      [OpBuilder<"Builder *builder, OperationState &result, Value *element, "
+                  "Type aggregateType",
+                  [{ build(builder, result, aggregateType, element); }]>];
+
+  let hasFolder = 1;
+}
+
 def SubFOp : FloatArithmeticOp<"subf"> {
   let summary = "floating point subtraction operation";
   let hasFolder = 1;

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -237,17 +237,6 @@ public:
     return builder.create<LLVM::ConstantOp>(loc, getIndexType(), attr);
   }
 
-  // Get the array attribute named "position" containing the given list of
-  // integers as integer attribute elements.
-  static ArrayAttr getIntegerArrayAttr(ConversionPatternRewriter &builder,
-                                       ArrayRef<int64_t> values) {
-    SmallVector<Attribute, 4> attrs;
-    attrs.reserve(values.size());
-    for (int64_t pos : values)
-      attrs.push_back(builder.getIntegerAttr(builder.getIndexType(), pos));
-    return builder.getArrayAttr(attrs);
-  }
-
   // Extract raw data pointer value from a value representing a memref.
   static Value *extractMemRefElementPtr(ConversionPatternRewriter &builder,
                                         Location loc,
@@ -260,7 +249,7 @@ public:
     else
       return builder.create<LLVM::ExtractValueOp>(
           loc, elementTypePtr, convertedMemRefValue,
-          getIntegerArrayAttr(builder, 0));
+          builder.getIndexArrayAttr(0));
     return buffer;
   }
 
@@ -1097,6 +1086,39 @@ struct CondBranchOpLowering
   using Super::Super;
 };
 
+// The Splat operation is lowered to an insertelement + a shufflevector
+// operation. Splat to only 1-d vector result types are lowered.
+struct SplatOpLowering : public LLVMLegalizationPattern<SplatOp> {
+  using LLVMLegalizationPattern<SplatOp>::LLVMLegalizationPattern;
+
+  PatternMatchResult
+  matchAndRewrite(Operation *op, ArrayRef<Value *> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto splatOp = cast<SplatOp>(op);
+    VectorType resultType = splatOp.getType().dyn_cast<VectorType>();
+    if (!resultType || resultType.getRank() != 1)
+      return matchFailure();
+
+    // First insert it into an undef vector so we can shuffle it.
+    auto vectorType = lowering.convertType(splatOp.getType());
+    Value *undef = rewriter.create<LLVM::UndefOp>(op->getLoc(), vectorType);
+    auto zero = rewriter.create<LLVM::ConstantOp>(
+        op->getLoc(), lowering.convertType(rewriter.getIntegerType(32)),
+        rewriter.getZeroAttr(rewriter.getIntegerType(32)));
+
+    auto v = rewriter.create<LLVM::InsertElementOp>(
+        op->getLoc(), vectorType, undef, splatOp.getOperand(), zero);
+
+    int64_t width = splatOp.getType().cast<VectorType>().getDimSize(0);
+    SmallVector<int32_t, 4> zeroValues(width, 0);
+
+    // Shuffle the value across the desired number of elements.
+    ArrayAttr zeroAttrs = rewriter.getI32ArrayAttr(zeroValues);
+    rewriter.replaceOpWithNewOp<LLVM::ShuffleVectorOp>(op, v, undef, zeroAttrs);
+    return matchSuccess();
+  }
+};
+
 } // namespace
 
 static void ensureDistinctSuccessors(Block &bb) {
@@ -1158,9 +1180,9 @@ void mlir::populateStdToLLVMConversionPatterns(
       DivFOpLowering, FuncOpConversion, IndexCastOpLowering, LoadOpLowering,
       MemRefCastOpLowering, MulFOpLowering, MulIOpLowering, OrOpLowering,
       RemISOpLowering, RemIUOpLowering, RemFOpLowering, ReturnOpLowering,
-      SelectOpLowering, SignExtendIOpLowering, SIToFPLowering, StoreOpLowering,
-      SubFOpLowering, SubIOpLowering, TruncateIOpLowering, XOrOpLowering,
-      ZeroExtendIOpLowering>(*converter.getDialect(), converter);
+      SelectOpLowering, SIToFPLowering, SignExtendIOpLowering, SplatOpLowering,
+      StoreOpLowering, SubFOpLowering, SubIOpLowering, TruncateIOpLowering,
+      XOrOpLowering, ZeroExtendIOpLowering>(*converter.getDialect(), converter);
 }
 
 // Convert types using the stored LLVM IR module.

--- a/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
+++ b/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
@@ -552,3 +552,18 @@ func @vec_bin(%arg0: vector<2x2x2xf32>) -> vector<2x2x2xf32> {
 // And we're done
 //   CHECK-NEXT: return
 }
+
+// CHECK-LABEL: @splat
+// CHECK-SAME: [[A:%arg[0-9]+]]: !llvm<"<4 x float>">
+// CHECK-SAME: [[ELT:%arg[0-9]+]]: !llvm.float
+func @splat(%a: vector<4xf32>, %b: f32) -> vector<4xf32> {
+  %vb = splat %b : vector<4xf32>
+  %r = mulf %a, %vb : vector<4xf32>
+  return %r : vector<4xf32>
+}
+// CHECK-NEXT: [[UNDEF:%[0-9]+]] = llvm.mlir.undef : !llvm<"<4 x float>">
+// CHECK-NEXT: [[ZERO:%[0-9]+]] = llvm.mlir.constant(0 : i32) : !llvm.i32
+// CHECK-NEXT: [[V:%[0-9]+]] = llvm.insertelement [[UNDEF]], [[ELT]], [[ZERO]] : !llvm<"<4 x float>">
+// CHECK-NEXT: [[SPLAT:%[0-9]+]] = llvm.shufflevector [[V]], [[UNDEF]] [0 : i32, 0 : i32, 0 : i32, 0 : i32]
+// CHECK-NEXT: [[SCALE:%[0-9]+]] = llvm.fmul [[A]], [[SPLAT]] : !llvm<"<4 x float>">
+// CHECK-NEXT: llvm.return [[SCALE]] : !llvm<"<4 x float>">

--- a/test/IR/core-ops.mlir
+++ b/test/IR/core-ops.mlir
@@ -467,6 +467,17 @@ func @test_dimop(%arg0: tensor<4x4x?xf32>) {
   return
 }
 
+// CHECK-LABEL: func @test_splat_op
+// CHECK-SAME: [[S:%arg[0-9]+]]: f32
+func @test_splat_op(%s : f32) {
+  %v = splat %s : vector<8xf32>
+  // CHECK: splat [[S]] : vector<8xf32>
+  %t = splat %s : tensor<8xf32>
+  // CHECK: splat [[S]] : tensor<8xf32>
+  %u = "std.splat"(%s) : (f32) -> vector<4xf32>
+  // CHECK: splat [[S]] : vector<4xf32>
+  return
+}
 
 // CHECK-LABEL: func @test_vector.transfer_ops(%arg0
 func @test_vector.transfer_ops(%arg0: memref<?x?xf32>) {

--- a/test/IR/invalid-ops.mlir
+++ b/test/IR/invalid-ops.mlir
@@ -821,3 +821,27 @@ func @return_not_in_function() {
   }): () -> ()
   return
 }
+
+// -----
+
+func @invalid_splat(%v : f32) {
+  splat %v : memref<8xf32>
+  // expected-error@-1 {{must be vector of any type values or statically shaped tensor of any type values}}
+  return
+}
+
+// -----
+
+func @invalid_splat(%v : vector<8xf32>) {
+  %w = splat %v : tensor<8xvector<8xf32>>
+  // expected-error@-1 {{must be integer or float type}}
+  return
+}
+
+// -----
+
+func @invalid_splat(%v : f32) { // expected-note {{prior use here}}
+  splat %v : vector<8xf64>
+  // expected-error@-1 {{expects different type than prior uses}}
+  return
+}

--- a/test/Transforms/constant-fold.mlir
+++ b/test/Transforms/constant-fold.mlir
@@ -540,3 +540,15 @@ func @custom_insertion_position() {
   }) : () -> ()
   return
 }
+
+// CHECK-LABEL: func @splat_fold
+func @splat_fold() -> (vector<4xf32>, tensor<4xf32>) {
+  %c = constant 1.0 : f32
+  %v = splat %c : vector<4xf32>
+  %t = splat %c : tensor<4xf32>
+  return %v, %t : vector<4xf32>, tensor<4xf32>
+
+  // CHECK-NEXT: [[V:%.*]] = constant dense<1.000000e+00> : vector<4xf32>
+  // CHECK-NEXT: [[T:%.*]] = constant dense<1.000000e+00> : tensor<4xf32>
+  // CHECK-NEXT: return [[V]], [[T]] : vector<4xf32>, tensor<4xf32>
+}

--- a/utils/vim/syntax/mlir.vim
+++ b/utils/vim/syntax/mlir.vim
@@ -31,7 +31,7 @@ syn match mlirType /x\s*\zsvector/
 " Operations.
 " Core ops (not exhaustive yet).
 " TODO: the list is not exhaustive.
-syn keyword mlirOps alloc addf addi call call_indirect cmpi constant dealloc dma_start dma_wait dim extract_element for getTensor if load memref_cast mulf muli store select subf subi tensor_cast
+syn keyword mlirOps alloc addf addi call call_indirect cmpi constant dealloc dma_start dma_wait dim extract_element for getTensor if load memref_cast mulf muli splat store select subf subi tensor_cast
 
 " Affine ops.
 syn match mlirOps /\<affine\.apply\>/


### PR DESCRIPTION
- introduce splat op in standard dialect (currently for int/float input
  type, output type can be vector or statically shaped tensor)
- implement LLVM lowering (when result type is 1-d vector)
- add constant folding hook for it
- while on Ops.cpp, fix some stale names

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>