### PR TITLE
Fix undefined reference to mlir::getElementTypeOrSelf(mlir::Type)

### DIFF
--- a/lib/Dialect/StandardOps/CMakeLists.txt
+++ b/lib/Dialect/StandardOps/CMakeLists.txt
@@ -5,5 +5,5 @@ add_llvm_library(MLIRStandardOps
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/StandardOps
   )
-add_dependencies(MLIRStandardOps MLIRStandardOpsIncGen LLVMSupport)
-target_link_libraries(MLIRStandardOps LLVMSupport)
+add_dependencies(MLIRStandardOps MLIRStandardOpsIncGen MLIRIR LLVMSupport)
+target_link_libraries(MLIRStandardOps MLIRIR LLVMSupport)


### PR DESCRIPTION


Fix undefined reference when:
`cmake --build . --target check-mlir`

mlir/lib/Dialect/StandardOps/Ops.cpp:2029:
undefined reference to `mlir::getElementTypeOrSelf(mlir::Type)

The mlir::getElementTypeOrSelf is defined under libMLIRIIR.a, so the dependency is needed for the user.