### PR TITLE
Integer right shift

### DIFF
--- a/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -145,6 +145,9 @@ def LLVM_SRemOp : LLVM_ArithmeticOp<"srem", "CreateSRem">;
 def LLVM_AndOp : LLVM_ArithmeticOp<"and", "CreateAnd">;
 def LLVM_OrOp : LLVM_ArithmeticOp<"or", "CreateOr">;
 def LLVM_XOrOp : LLVM_ArithmeticOp<"xor", "CreateXor">;
+def LLVM_ShlOp : LLVM_ArithmeticOp<"shl", "CreateShl">;
+def LLVM_LShrOp : LLVM_ArithmeticOp<"lshr", "CreateLShr">;
+def LLVM_AShrOp : LLVM_ArithmeticOp<"ashr", "CreateAShr">;
 
 // Predicate for integer comparisons.
 def ICmpPredicateEQ  : I64EnumAttrCase<"eq", 0>;

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -881,6 +881,14 @@ def ShlISOp : IntArithmeticOp<"shlis"> {
   let summary = "signed integer shift left";
 }
 
+def ShrISOp : IntArithmeticOp<"shris"> {
+  let summary = "signed integer shift right";
+}
+
+def ShrIUOp : IntArithmeticOp<"shriu"> {
+  let summary = "unsigned integer shift right";
+}
+
 def SplatOp : Std_Op<"splat", [NoSideEffect]> {
   let summary = "splat or broadcast operation";
   let description = [{

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -513,6 +513,9 @@ struct ConstLLVMOpLowering
     : public OneToOneLLVMOpLowering<ConstantOp, LLVM::ConstantOp> {
   using Super::Super;
 };
+struct ShlISOpLowering : public BinaryOpLLVMOpLowering<ShlISOp, LLVM::ShlOp> {
+  using Super::Super;
+};
 
 // Check if the MemRefType `type` is supported by the lowering. We currently
 // only support memrefs with identity maps.
@@ -1111,9 +1114,10 @@ void mlir::populateStdToLLVMConversionPatterns(
       DivFOpLowering, FuncOpConversion, IndexCastOpLowering, LoadOpLowering,
       MemRefCastOpLowering, MulFOpLowering, MulIOpLowering, OrOpLowering,
       RemISOpLowering, RemIUOpLowering, RemFOpLowering, ReturnOpLowering,
-      SelectOpLowering, SIToFPLowering, SignExtendIOpLowering, SplatOpLowering,
-      StoreOpLowering, SubFOpLowering, SubIOpLowering, TruncateIOpLowering,
-      XOrOpLowering, ZeroExtendIOpLowering>(*converter.getDialect(), converter);
+      SelectOpLowering, ShlISOpLowering, SIToFPLowering, SignExtendIOpLowering,
+      SplatOpLowering, StoreOpLowering, SubFOpLowering, SubIOpLowering,
+      TruncateIOpLowering, XOrOpLowering, ZeroExtendIOpLowering>(
+      *converter.getDialect(), converter);
 }
 
 // Convert types using the stored LLVM IR module.

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -516,6 +516,12 @@ struct ConstLLVMOpLowering
 struct ShlISOpLowering : public BinaryOpLLVMOpLowering<ShlISOp, LLVM::ShlOp> {
   using Super::Super;
 };
+struct ShrISOpLowering : public BinaryOpLLVMOpLowering<ShrISOp, LLVM::AShrOp> {
+  using Super::Super;
+};
+struct ShrIUOpLowering : public BinaryOpLLVMOpLowering<ShrIUOp, LLVM::LShrOp> {
+  using Super::Super;
+};
 
 // Check if the MemRefType `type` is supported by the lowering. We currently
 // only support memrefs with identity maps.
@@ -1114,10 +1120,10 @@ void mlir::populateStdToLLVMConversionPatterns(
       DivFOpLowering, FuncOpConversion, IndexCastOpLowering, LoadOpLowering,
       MemRefCastOpLowering, MulFOpLowering, MulIOpLowering, OrOpLowering,
       RemISOpLowering, RemIUOpLowering, RemFOpLowering, ReturnOpLowering,
-      SelectOpLowering, ShlISOpLowering, SIToFPLowering, SignExtendIOpLowering,
-      SplatOpLowering, StoreOpLowering, SubFOpLowering, SubIOpLowering,
-      TruncateIOpLowering, XOrOpLowering, ZeroExtendIOpLowering>(
-      *converter.getDialect(), converter);
+      SelectOpLowering, ShlISOpLowering, ShrISOpLowering, ShrIUOpLowering,
+      SIToFPLowering, SignExtendIOpLowering, SplatOpLowering, StoreOpLowering,
+      SubFOpLowering, SubIOpLowering, TruncateIOpLowering, XOrOpLowering,
+      ZeroExtendIOpLowering>(*converter.getDialect(), converter);
 }
 
 // Convert types using the stored LLVM IR module.

--- a/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
+++ b/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
@@ -383,6 +383,10 @@ func @vector_ops(vector<4xf32>, vector<4xi1>, vector<4xi64>) -> vector<4xf32> {
   %11 = xor %arg2, %arg2 : vector<4xi64>
 // CHECK-NEXT:  %11 = llvm.shl %arg2, %arg2 : !llvm<"<4 x i64>">
   %12 = shlis %arg2, %arg2 : vector<4xi64>
+// CHECK-NEXT:  %12 = llvm.ashr %arg2, %arg2 : !llvm<"<4 x i64>">
+  %13 = shris %arg2, %arg2 : vector<4xi64>
+// CHECK-NEXT:  %13 = llvm.lshr %arg2, %arg2 : !llvm<"<4 x i64>">
+  %14 = shriu %arg2, %arg2 : vector<4xi64>
   return %1 : vector<4xf32>
 }
 
@@ -417,6 +421,10 @@ func @ops(f32, f32, i32, i32) -> (f32, i32) {
   %13 = xor %arg2, %arg3 : i32
 // CHECK-NEXT: %13 = llvm.shl %arg2, %arg3 : !llvm.i32
   %14 = shlis %arg2, %arg3 : i32
+// CHECK-NEXT: %14 = llvm.ashr %arg2, %arg3 : !llvm.i32
+  %15 = shris %arg2, %arg3 : i32
+// CHECK-NEXT: %15 = llvm.lshr %arg2, %arg3 : !llvm.i32
+  %16 = shriu %arg2, %arg3 : i32
   return %0, %4 : f32, i32
 }
 

--- a/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
+++ b/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
@@ -381,6 +381,8 @@ func @vector_ops(vector<4xf32>, vector<4xi1>, vector<4xi64>) -> vector<4xf32> {
   %10 = or %arg2, %arg2 : vector<4xi64>
 // CHECK-NEXT:  %10 = llvm.xor %arg2, %arg2 : !llvm<"<4 x i64>">
   %11 = xor %arg2, %arg2 : vector<4xi64>
+// CHECK-NEXT:  %11 = llvm.shl %arg2, %arg2 : !llvm<"<4 x i64>">
+  %12 = shlis %arg2, %arg2 : vector<4xi64>
   return %1 : vector<4xf32>
 }
 
@@ -413,7 +415,8 @@ func @ops(f32, f32, i32, i32) -> (f32, i32) {
   %12 = or %arg2, %arg3 : i32
 // CHECK-NEXT: %12 = llvm.xor %arg2, %arg3 : !llvm.i32
   %13 = xor %arg2, %arg3 : i32
-
+// CHECK-NEXT: %13 = llvm.shl %arg2, %arg3 : !llvm.i32
+  %14 = shlis %arg2, %arg3 : i32
   return %0, %4 : f32, i32
 }
 

--- a/test/IR/core-ops.mlir
+++ b/test/IR/core-ops.mlir
@@ -345,6 +345,21 @@ func @standard_instrs(tensor<4x4x?xf32>, f32, i32, index, i64) {
   // CHECK: %{{[0-9]+}} = trunci %cst_4 : tensor<42xi32>
   %93 = trunci %tci32 : tensor<42 x i32> to tensor<42 x i16>
 
+  // CHECK: %{{[0-9]+}} = shlis %arg2, %arg2 : i32
+  %94 = "std.shlis"(%i, %i) : (i32, i32) -> i32
+
+  // CHECK:%{{[0-9]+}} = shlis %4, %4 : i32
+  %95 = shlis %i2, %i2 : i32
+
+  // CHECK: %{{[0-9]+}} = shlis %arg3, %arg3 : index
+  %96 = shlis %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = shlis %cst_5, %cst_5 : vector<42xi32>
+  %97 = shlis %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = shlis %cst_4, %cst_4 : tensor<42xi32>
+  %98 = shlis %tci32, %tci32 : tensor<42 x i32>
+
   return
 }
 

--- a/test/IR/core-ops.mlir
+++ b/test/IR/core-ops.mlir
@@ -360,6 +360,36 @@ func @standard_instrs(tensor<4x4x?xf32>, f32, i32, index, i64) {
   // CHECK: %{{[0-9]+}} = shlis %cst_4, %cst_4 : tensor<42xi32>
   %98 = shlis %tci32, %tci32 : tensor<42 x i32>
 
+  // CHECK: %{{[0-9]+}} = shris %arg2, %arg2 : i32
+  %99 = "std.shris"(%i, %i) : (i32, i32) -> i32
+
+  // CHECK:%{{[0-9]+}} = shris %4, %4 : i32
+  %100 = shris %i2, %i2 : i32
+
+  // CHECK: %{{[0-9]+}} = shris %arg3, %arg3 : index
+  %101 = shris %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = shris %cst_5, %cst_5 : vector<42xi32>
+  %102 = shris %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = shris %cst_4, %cst_4 : tensor<42xi32>
+  %103 = shris %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = shriu %arg2, %arg2 : i32
+  %104 = "std.shriu"(%i, %i) : (i32, i32) -> i32
+
+  // CHECK:%{{[0-9]+}} = shriu %4, %4 : i32
+  %105 = shriu %i2, %i2 : i32
+
+  // CHECK: %{{[0-9]+}} = shriu %arg3, %arg3 : index
+  %106 = shriu %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = shriu %cst_5, %cst_5 : vector<42xi32>
+  %107 = shriu %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = shriu %cst_4, %cst_4 : tensor<42xi32>
+  %108 = shriu %tci32, %tci32 : tensor<42 x i32>
+
   return
 }
 

--- a/test/Target/llvmir.mlir
+++ b/test/Target/llvmir.mlir
@@ -797,6 +797,13 @@ func @ops(%arg0: !llvm.float, %arg1: !llvm.float, %arg2: !llvm.i32, %arg3: !llvm
 // CHECK-NEXT: %19 = xor i32 %2, %3
   %15 = llvm.xor %arg2, %arg3 : !llvm.i32
 
+// CHECK-NEXT: %20 = shl i32 %2, %3
+  %16 = llvm.shl %arg2, %arg3 : !llvm.i32
+// CHECK-NEXT: %21 = lshr i32 %2, %3
+  %17 = llvm.lshr %arg2, %arg3 : !llvm.i32
+// CHECK-NEXT: %22 = ashr i32 %2, %3
+  %18 = llvm.ashr %arg2, %arg3 : !llvm.i32
+
   llvm.return %10 : !llvm<"{ float, i32 }">
 }
 

--- a/test/Target/llvmir.mlir
+++ b/test/Target/llvmir.mlir
@@ -758,6 +758,14 @@ func @vector_ops(%arg0: !llvm<"<4 x float>">, %arg1: !llvm<"<4 x i1>">, %arg2: !
   %10 = llvm.or %arg2, %arg2 : !llvm<"<4 x i64>">
 // CHECK-NEXT: %14 = xor <4 x i64> %2, %2
   %11 = llvm.xor %arg2, %arg2 : !llvm<"<4 x i64>">
+
+// CHECK-NEXT: %15 = shl <4 x i64> %2, %2
+  %12 = llvm.shl %arg2, %arg2 : !llvm<"<4 x i64>">
+// CHECK-NEXT: %16 = lshr <4 x i64> %2, %2
+  %13 = llvm.lshr %arg2, %arg2 : !llvm<"<4 x i64>">
+// CHECK-NEXT: %17 = ashr <4 x i64> %2, %2
+  %14 = llvm.ashr %arg2, %arg2 : !llvm<"<4 x i64>">
+
 // CHECK-NEXT:    ret <4 x float> %4
   llvm.return %1 : !llvm<"<4 x float>">
 }


### PR DESCRIPTION
MLIR has already a std.shlis op but no lowering to LLVM.
This commit adds the lowering and complements std.shlis by std.shris and std.shriu. The latter ones are lowered to llvm.ashr and llvm.lshr.
