### PR TITLE
[spirv] Add array length check.

### DIFF
--- a/lib/Dialect/SPIRV/SPIRVDialect.cpp
+++ b/lib/Dialect/SPIRV/SPIRVDialect.cpp
@@ -194,6 +194,13 @@ static Type parseArrayType(SPIRVDialect const &dialect, StringRef spec,
     return Type();
   }
 
+  // According to the SPIR-V spec:
+  // "Length is the number of elements in the array. It must be at least 1."
+  if (!count) {
+    emitError(loc, "expected array length greater than 0");
+    return Type();
+  }
+
   if (spec.trim().empty()) {
     emitError(loc, "expected element type");
     return Type();

--- a/lib/Dialect/SPIRV/SPIRVTypes.cpp
+++ b/lib/Dialect/SPIRV/SPIRVTypes.cpp
@@ -56,12 +56,14 @@ struct spirv::detail::ArrayTypeStorage : public TypeStorage {
 };
 
 ArrayType ArrayType::get(Type elementType, unsigned elementCount) {
+  assert(elementCount && "ArrayType needs at least one element");
   return Base::get(elementType.getContext(), TypeKind::Array, elementType,
                    elementCount, 0);
 }
 
 ArrayType ArrayType::get(Type elementType, unsigned elementCount,
                          ArrayType::LayoutInfo layoutInfo) {
+  assert(elementCount && "ArrayType needs at least one element");
   return Base::get(elementType.getContext(), TypeKind::Array, elementType,
                    elementCount, layoutInfo);
 }

--- a/test/Dialect/SPIRV/types.mlir
+++ b/test/Dialect/SPIRV/types.mlir
@@ -82,6 +82,11 @@ func @array_type_zero_stide(!spv.array<4xi32 [0]>) -> ()
 
 // -----
 
+// expected-error @+1 {{expected array length greater than 0}}
+func @array_type_zero_length(!spv.array<0xf32>) -> ()
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // PointerType
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
According to the SPIR-V spec:
"Length is the number of elements in the array. It must be at least 1."

@antiagainst @MaheshRavishankar can you please take a look?
Thanks!