### PR TITLE
Add support for some multi-store cases in affine loop fusion

### DIFF
--- a/test/Transforms/loop-fusion.mlir
+++ b/test/Transforms/loop-fusion.mlir
@@ -2285,11 +2285,11 @@ func @should_fuse_self_dependence_multi_store_producer() {
   affine.for %i1 = 0 to 10 {
     %v1 = affine.load %m[%i1] : memref<10xf32>
   }
-  // CHECK:      affine.for [[i0:%.*]] = 0 to 10 {
-  // CHECK-NEXT:   affine.store {{%.*}}, [[LOCAL_M:%.*]]{{\[}}[[i0]]{{\]}} : memref<10xf32>
-  // CHECK-NEXT:   [[v0:%.*]] = affine.load [[LOCAL_M]]{{\[}}[[i0]]{{\]}} : memref<10xf32>
+  // CHECK:      affine.for %[[i0:.*]] = 0 to 10 {
+  // CHECK-NEXT:   affine.store %{{.*}}, [[LOCAL_M:%.*]][%[[i0]]] : memref<10xf32>
+  // CHECK-NEXT:   [[v0:%.*]] = affine.load [[LOCAL_M]][%[[i0]]] : memref<10xf32>
   // CHECK-NEXT:   affine.store [[v0]], %{{.*}}[0] : memref<1xf32>
-  // CHECK-NEXT:   %{{.*}} = affine.load %{{.*}}[0] : memref<1xf32>
+  // CHECK-NEXT:   affine.load %{{.*}}[0] : memref<1xf32>
   // CHECK-NEXT: }
   // CHECK-NEXT: return
   return
@@ -2310,10 +2310,10 @@ func @should_fuse_dead_multi_store_producer() {
   affine.for %i1 = 0 to 10 {
     %v0 = affine.load %m[%i1] : memref<10xf32>
   }
-  // CHECK:      affine.for [[i0:%.*]] = 0 to 10 {
-  // CHECK-NEXT:   affine.store {{%.*}}, {{%.*\[}}[[i0]]{{\]}} : memref<10xf32>
-  // CHECK-NEXT:   affine.store {{%.*}}, %{{.*}}[0] : memref<1xf32>
-  // CHECK-NEXT:   %{{.*}} = affine.load %{{.*}}[0] : memref<1xf32>
+  // CHECK:      affine.for %[[i0:.*]] = 0 to 10 {
+  // CHECK-NEXT:   affine.store %{{.*}}, %{{.*}}[%[[i0]]] : memref<10xf32>
+  // CHECK-NEXT:   affine.store %{{.*}}, %{{.*}}[0] : memref<1xf32>
+  // CHECK-NEXT:   affine.load %{{.*}}[0] : memref<1xf32>
   // CHECK-NEXT: }
   // CHECK-NEXT: return
   return
@@ -2333,10 +2333,10 @@ func @should_fuse_function_live_out_multi_store_producer(%live_out_m : memref<10
   affine.for %i1 = 0 to 10 {
     %v0 = affine.load %m[%i1] : memref<10xf32>
   }
-  // CHECK:      affine.for [[i0:%.*]] = 0 to 10 {
-  // CHECK-NEXT:   affine.store {{%.*}}, {{%.*\[}}[[i0]]{{\]}} : memref<10xf32>
-  // CHECK-NEXT:   affine.store {{%.*}}, {{%.*\[}}[[i0]]{{\]}} : memref<10xf32>
-  // CHECK-NEXT:   %{{.*}} = affine.load {{%.*\[}}[[i0]]{{\]}} : memref<10xf32>
+  // CHECK:      affine.for %[[i0:.*]] = 0 to 10 {
+  // CHECK-NEXT:   affine.store %{{.*}}, %{{.*}}[%[[i0]]] : memref<10xf32>
+  // CHECK-NEXT:   affine.store %{{.*}}, %{{.*}}[%[[i0]]] : memref<10xf32>
+  // CHECK-NEXT:   affine.load %{{.*}}[%[[i0]]] : memref<10xf32>
   // CHECK-NEXT: }
   // CHECK-NEXT: return
   return

--- a/test/Transforms/loop-fusion.mlir
+++ b/test/Transforms/loop-fusion.mlir
@@ -1251,6 +1251,7 @@ func @should_not_fuse_multi_output_producer() {
   }
   affine.for %i1 = 0 to 10 {
     %v0 = affine.load %a[%i1] : memref<10xf32>
+    %v1 = affine.load %b[%i1] : memref<10xf32>
   }
 
   // CHECK:       affine.for %{{.*}} = 0 to 10 {
@@ -1258,6 +1259,7 @@ func @should_not_fuse_multi_output_producer() {
   // CHECK-NEXT:    affine.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<10xf32>
   // CHECK-NEXT:  }
   // CHECK-NEXT:  affine.for %{{.*}} = 0 to 10 {
+  // CHECK-NEXT:    %{{.*}} = affine.load %{{.*}}[%{{.*}}] : memref<10xf32>
   // CHECK-NEXT:    %{{.*}} = affine.load %{{.*}}[%{{.*}}] : memref<10xf32>
   // CHECK-NEXT:  }
   // CHECK-NEXT:  return
@@ -2264,5 +2266,78 @@ func @affine_2_dependent_mm_fused(%arg0: memref<1024x1024xf32>, %arg1: memref<10
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @should_fuse_self_dependence_multi_store_producer() {
+func @should_fuse_self_dependence_multi_store_producer() {
+  %m = alloc() : memref<10xf32>
+  %local_m = alloc() : memref<10xf32>
+  %cf7 = constant 7.0 : f32
+
+  affine.for %i0 = 0 to 10 {
+    affine.store %cf7, %local_m[%i0] : memref<10xf32>
+    %v0 = affine.load %local_m[%i0] : memref<10xf32>
+    affine.store %v0, %m[%i0] : memref<10xf32>
+  }
+  affine.for %i1 = 0 to 10 {
+    %v1 = affine.load %m[%i1] : memref<10xf32>
+  }
+  // CHECK:      affine.for [[i0:%.*]] = 0 to 10 {
+  // CHECK-NEXT:   affine.store {{%.*}}, [[LOCAL_M:%.*]]{{\[}}[[i0]]{{\]}} : memref<10xf32>
+  // CHECK-NEXT:   [[v0:%.*]] = affine.load [[LOCAL_M]]{{\[}}[[i0]]{{\]}} : memref<10xf32>
+  // CHECK-NEXT:   affine.store [[v0]], %{{.*}}[0] : memref<1xf32>
+  // CHECK-NEXT:   %{{.*}} = affine.load %{{.*}}[0] : memref<1xf32>
+  // CHECK-NEXT: }
+  // CHECK-NEXT: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @should_fuse_dead_multi_store_producer() {
+func @should_fuse_dead_multi_store_producer() {
+  %m = alloc() : memref<10xf32>
+  %dead_m = alloc() : memref<10xf32>
+  %cf7 = constant 7.0 : f32
+
+  affine.for %i0 = 0 to 10 {
+    affine.store %cf7, %dead_m[%i0] : memref<10xf32>
+    affine.store %cf7, %m[%i0] : memref<10xf32>
+  }
+  affine.for %i1 = 0 to 10 {
+    %v0 = affine.load %m[%i1] : memref<10xf32>
+  }
+  // CHECK:      affine.for [[i0:%.*]] = 0 to 10 {
+  // CHECK-NEXT:   affine.store {{%.*}}, {{%.*\[}}[[i0]]{{\]}} : memref<10xf32>
+  // CHECK-NEXT:   affine.store {{%.*}}, %{{.*}}[0] : memref<1xf32>
+  // CHECK-NEXT:   %{{.*}} = affine.load %{{.*}}[0] : memref<1xf32>
+  // CHECK-NEXT: }
+  // CHECK-NEXT: return
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @should_fuse_function_live_out_multi_store_producer
+func @should_fuse_function_live_out_multi_store_producer(%live_out_m : memref<10xf32>) {
+  %m = alloc() : memref<10xf32>
+  %cf7 = constant 7.0 : f32
+
+  affine.for %i0 = 0 to 10 {
+    affine.store %cf7, %live_out_m[%i0] : memref<10xf32>
+    affine.store %cf7, %m[%i0] : memref<10xf32>
+  }
+  affine.for %i1 = 0 to 10 {
+    %v0 = affine.load %m[%i1] : memref<10xf32>
+  }
+  // CHECK:      affine.for [[i0:%.*]] = 0 to 10 {
+  // CHECK-NEXT:   affine.store {{%.*}}, {{%.*\[}}[[i0]]{{\]}} : memref<10xf32>
+  // CHECK-NEXT:   affine.store {{%.*}}, {{%.*\[}}[[i0]]{{\]}} : memref<10xf32>
+  // CHECK-NEXT:   %{{.*}} = affine.load {{%.*\[}}[[i0]]{{\]}} : memref<10xf32>
+  // CHECK-NEXT: }
+  // CHECK-NEXT: return
   return
 }

--- a/test/Transforms/loop-fusion.mlir
+++ b/test/Transforms/loop-fusion.mlir
@@ -2322,12 +2322,12 @@ func @should_fuse_dead_multi_store_producer() {
 // -----
 
 // CHECK-LABEL: func @should_fuse_function_live_out_multi_store_producer
-func @should_fuse_function_live_out_multi_store_producer(%live_out_m : memref<10xf32>) {
+func @should_fuse_function_live_out_multi_store_producer(%live_in_out_m : memref<10xf32>) {
   %m = alloc() : memref<10xf32>
   %cf7 = constant 7.0 : f32
 
   affine.for %i0 = 0 to 10 {
-    affine.store %cf7, %live_out_m[%i0] : memref<10xf32>
+    affine.store %cf7, %live_in_out_m[%i0] : memref<10xf32>
     affine.store %cf7, %m[%i0] : memref<10xf32>
   }
   affine.for %i1 = 0 to 10 {


### PR DESCRIPTION
Hello!

We've been giving affine loop fusion a try and we are pretty happy with the initial results! Great work! We are seeing quite a few loop nests being fused in our models!

We noticed that currently only single-store producer loops are supported and would like to contribute a fix for that since it seems to be an important limitation. Even though our loop nests usually have a single store, this limitation is exposed when several single-store loop nests can be fused. The following example is a snippet of a model we are working on, where 4 loop nests could be fused into a single one:

```
func @main(%in : memref<1048576x256xf32>, %out : memref<1048576x256xf32>) {
  %cst = constant 0.000000e+00 : f32

  %6 = alloc() : memref<1048576x256xf32>
  affine.for %arg7 = 0 to 1048576 {
    affine.for %arg8 = 0 to 256 {
      %13 = affine.load %in[%arg7, %arg8] : memref<1048576x256xf32>
      %14 = affine.load %in[%arg7, %arg8] : memref<1048576x256xf32>
      %15 = mulf %14, %13 : f32
      affine.store %15, %6[%arg7, %arg8] : memref<1048576x256xf32>
    }
  }
  %7 = alloc() : memref<1048576x256xf32>
  affine.for %arg7 = 0 to 1048576 {
    affine.for %arg8 = 0 to 256 {
      %13 = affine.load %6[%arg7, %arg8] : memref<1048576x256xf32>
      %14 = cmpf "ogt", %13, %cst : f32
      %15 = select %14, %13, %cst : f32
      affine.store %15, %7[%arg7, %arg8] : memref<1048576x256xf32>
    }
  }
  %8 = alloc() : memref<1048576x256xf32>
  affine.for %arg7 = 0 to 1048576 {
    affine.for %arg8 = 0 to 256 {
      %13 = affine.load %7[%arg7, %arg8] : memref<1048576x256xf32>
      %14 = affine.load %7[%arg7, %arg8] : memref<1048576x256xf32>
      %15 = mulf %14, %13 : f32
      affine.store %15, %8[%arg7, %arg8] : memref<1048576x256xf32>
    }
  }
  affine.for %arg7 = 0 to 1048576 {
    affine.for %arg8 = 0 to 256 {
      %13 = affine.load %8[%arg7, %arg8] : memref<1048576x256xf32>
      %14 = cmpf "ogt", %13, %cst : f32
      %15 = select %14, %13, %cst : f32
      affine.store %15, %out[%arg7, %arg8] : memref<1048576x256xf32>
    }
  }
  dealloc %6 : memref<1048576x256xf32>
  dealloc %7 : memref<1048576x256xf32>
  dealloc %8 : memref<1048576x256xf32>
  return
}
```  

However, affine loop fusion only fuses the first 3 loops and not the 4th one:

```
module {
  func @main(%arg0: memref<1048576x256xf32>, %arg1: memref<1048576x256xf32>) {
    %cst = constant 0.000000e+00 : f32
    %0 = alloc() : memref<1048576x256xf32>
    %1 = alloc() : memref<1048576x256xf32>
    %2 = alloc() : memref<1048576x256xf32>
    affine.for %arg2 = 0 to 1048576 {
      affine.for %arg3 = 0 to 256 {
        %3 = affine.load %arg0[%arg2, %arg3] : memref<1048576x256xf32>
        %4 = affine.load %arg0[%arg2, %arg3] : memref<1048576x256xf32>
        %5 = mulf %4, %3 : f32
        affine.store %5, %0[%arg2, %arg3] : memref<1048576x256xf32>
        %6 = affine.load %0[%arg2, %arg3] : memref<1048576x256xf32>
        %7 = cmpf "ogt", %6, %cst : f32
        %8 = select %7, %6, %cst : f32
        affine.store %8, %1[%arg2, %arg3] : memref<1048576x256xf32>
        %9 = affine.load %1[%arg2, %arg3] : memref<1048576x256xf32>
        %10 = affine.load %1[%arg2, %arg3] : memref<1048576x256xf32>
        %11 = mulf %10, %9 : f32
        affine.store %11, %2[%arg2, %arg3] : memref<1048576x256xf32>
      }
    }
    affine.for %arg2 = 0 to 1048576 {
      affine.for %arg3 = 0 to 256 {
        %3 = affine.load %2[%arg2, %arg3] : memref<1048576x256xf32>
        %4 = cmpf "ogt", %3, %cst : f32
        %5 = select %4, %3, %cst : f32
        affine.store %5, %arg1[%arg2, %arg3] : memref<1048576x256xf32>
      }
    }
    dealloc %0 : memref<1048576x256xf32>
    dealloc %1 : memref<1048576x256xf32>
    dealloc %2 : memref<1048576x256xf32>
    return
  }
}
```

This happens because the algorithm starts with the 3rd loop nest as consumer and it fuses 2nd and 1st one into it. Then, it picks 4th as consumer and tries to fuse the previously fused one into it, which it's not possible because it has multiple stores.

This PR is a stepping stone towards supporting generic multi-store producer loop nests in affine loop fusion. It extends the algorithm to support fusion of multi-store producer loop nests that:
 1. have only one store that writes to a function-local live out, and
 2. the remaining stores are only involved in loop nest self dependences or no dependences within the function.

It would be great to get feedback on this fix, if this approach is aligned with what you envision for the generic multi-output problem and if there are more cases that could be problematic and are currently not properly addressed in this PR.

Thanks!
Diego