### PR TITLE
Use correct spelling in functions for quantization

### DIFF
--- a/include/mlir/Dialect/QuantOps/QuantTypes.h
+++ b/include/mlir/Dialect/QuantOps/QuantTypes.h
@@ -88,7 +88,7 @@ public:
 
   /// Gets the minimum possible stored by a storageType. storageTypeMin must
   /// be greater than or equal to this value.
-  static int64_t getDefaultMininumForInteger(bool isSigned,
+  static int64_t getDefaultMinimumForInteger(bool isSigned,
                                              unsigned integralWidth) {
     if (isSigned) {
       return llvm::minIntN(integralWidth);
@@ -98,7 +98,7 @@ public:
 
   /// Gets the maximum possible stored by a storageType. storageTypeMax must
   /// be less than or equal to this value.
-  static int64_t getDefaultMaxinumForInteger(bool isSigned,
+  static int64_t getDefaultMaximumForInteger(bool isSigned,
                                              unsigned integralWidth) {
     if (isSigned) {
       return llvm::maxIntN(integralWidth);

--- a/lib/Dialect/QuantOps/IR/QuantTypes.cpp
+++ b/lib/Dialect/QuantOps/IR/QuantTypes.cpp
@@ -60,9 +60,9 @@ LogicalResult QuantizedType::verifyConstructionInvariants(
   bool isSigned =
       (flags & QuantizationFlags::Signed) == QuantizationFlags::Signed;
   int64_t defaultIntegerMin =
-      getDefaultMininumForInteger(isSigned, integralWidth);
+      getDefaultMinimumForInteger(isSigned, integralWidth);
   int64_t defaultIntegerMax =
-      getDefaultMaxinumForInteger(isSigned, integralWidth);
+      getDefaultMaximumForInteger(isSigned, integralWidth);
   if (storageTypeMax - storageTypeMin <= 0 ||
       storageTypeMin < defaultIntegerMin ||
       storageTypeMax > defaultIntegerMax) {

--- a/lib/Dialect/QuantOps/IR/TypeParser.cpp
+++ b/lib/Dialect/QuantOps/IR/TypeParser.cpp
@@ -519,9 +519,9 @@ bool TypeParser::parseStorageRange(IntegerType storageType, bool isSigned,
                                    int64_t &storageTypeMin,
                                    int64_t &storageTypeMax) {
 
-  int64_t defaultIntegerMin = QuantizedType::getDefaultMininumForInteger(
+  int64_t defaultIntegerMin = QuantizedType::getDefaultMinimumForInteger(
       isSigned, storageType.getWidth());
-  int64_t defaultIntegerMax = QuantizedType::getDefaultMaxinumForInteger(
+  int64_t defaultIntegerMax = QuantizedType::getDefaultMaximumForInteger(
       isSigned, storageType.getWidth());
   if (consumeIf(TokenKind::l_angle)) {
     // Explicit storage min and storage max.
@@ -639,9 +639,9 @@ static void printStorageType(QuantizedType type, raw_ostream &out) {
 
   // storageTypeMin and storageTypeMax if not default.
   int64_t defaultIntegerMin =
-      QuantizedType::getDefaultMininumForInteger(isSigned, storageWidth);
+      QuantizedType::getDefaultMinimumForInteger(isSigned, storageWidth);
   int64_t defaultIntegerMax =
-      QuantizedType::getDefaultMaxinumForInteger(isSigned, storageWidth);
+      QuantizedType::getDefaultMaximumForInteger(isSigned, storageWidth);
   if (defaultIntegerMin != type.getStorageTypeMin() ||
       defaultIntegerMax != type.getStorageTypeMax()) {
     out << "<" << type.getStorageTypeMin() << ":" << type.getStorageTypeMax()


### PR DESCRIPTION
This PR renames these two functions using correct spelling
```
getDefaultMaxinumForInteger() -> getDefaultMaximumForInteger()
getDefaultMininumForInteger() -> getDefaultMinimumForInteger()
```

These functions are called from [another repository](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/mlir/lite/transforms/load_quantization_recipe.cc#L78-L85). After merging this PR, I will create a PR at [another repository](https://github.com/tensorflow/tensorflow).