### PR TITLE
minor spelling tweaks under bindings, examples, g3doc,  test, unittests, and utils

### DIFF
--- a/bindings/python/pybind.cpp
+++ b/bindings/python/pybind.cpp
@@ -397,7 +397,7 @@ public:
   }
 
   // EDSC maintain an implicit stack of builders (mostly for keeping track of
-  // insretion points); every operation gets inserted using the top-of-the-stack
+  // insertion points); every operation gets inserted using the top-of-the-stack
   // builder.  Creating a new EDSC Builder automatically puts it on the stack,
   // effectively entering the block for it.
   void createBlockBuilder() {
@@ -422,7 +422,7 @@ public:
   PythonBlockHandle getHandle() { return handle; }
 
   // EDSC maintain an implicit stack of builders (mostly for keeping track of
-  // insretion points); every operation gets inserted using the top-of-the-stack
+  // insertion points); every operation gets inserted using the top-of-the-stack
   // builder.  Calling operator() on a builder pops the builder from the stack,
   // effectively resetting the insertion point to its position before we entered
   // the block.
@@ -523,7 +523,7 @@ struct PythonIndexedValue {
 
   void store(const std::vector<PythonValueHandle> &indices,
              PythonValueHandle value) {
-    // Uses the overloaded `opreator=` to emit a store.
+    // Uses the overloaded `operator=` to emit a store.
     index(indices).indexed = value.value;
   }
 

--- a/examples/toy/Ch1/include/toy/Parser.h
+++ b/examples/toy/Ch1/include/toy/Parser.h
@@ -97,7 +97,7 @@ private:
   /// Parse a literal array expression.
   /// tensorLiteral ::= [ literalList ] | number
   /// literalList ::= tensorLiteral | tensorLiteral, literalList
-  std::unique_ptr<ExprAST> ParseTensorLitteralExpr() {
+  std::unique_ptr<ExprAST> ParseTensorLiteralExpr() {
     auto loc = lexer.getLastLocation();
     lexer.consume(Token('['));
 
@@ -108,7 +108,7 @@ private:
     do {
       // We can have either another nested array or a number literal.
       if (lexer.getCurToken() == '[') {
-        values.push_back(ParseTensorLitteralExpr());
+        values.push_back(ParseTensorLiteralExpr());
         if (!values.back())
           return nullptr; // parse error in the nested array.
       } else {
@@ -236,7 +236,7 @@ private:
     case '(':
       return ParseParenExpr();
     case '[':
-      return ParseTensorLitteralExpr();
+      return ParseTensorLiteralExpr();
     case ';':
       return nullptr;
     case '}':

--- a/examples/toy/Ch1/parser/AST.cpp
+++ b/examples/toy/Ch1/parser/AST.cpp
@@ -125,7 +125,7 @@ void ASTDumper::dump(NumberExprAST *num) {
   llvm::errs() << num->getValue() << " " << loc(num) << "\n";
 }
 
-/// Helper to print recurisvely a literal. This handles nested array like:
+/// Helper to print recursively a literal. This handles nested array like:
 ///    [ [ 1, 2 ], [ 3, 4 ] ]
 /// We print out such array with the dimensions spelled out at every level:
 ///    <2,2>[<2>[ 1, 2 ], <2>[ 3, 4 ] ]

--- a/examples/toy/Ch2/include/toy/Parser.h
+++ b/examples/toy/Ch2/include/toy/Parser.h
@@ -97,7 +97,7 @@ private:
   /// Parse a literal array expression.
   /// tensorLiteral ::= [ literalList ] | number
   /// literalList ::= tensorLiteral | tensorLiteral, literalList
-  std::unique_ptr<ExprAST> ParseTensorLitteralExpr() {
+  std::unique_ptr<ExprAST> ParseTensorLiteralExpr() {
     auto loc = lexer.getLastLocation();
     lexer.consume(Token('['));
 
@@ -108,7 +108,7 @@ private:
     do {
       // We can have either another nested array or a number literal.
       if (lexer.getCurToken() == '[') {
-        values.push_back(ParseTensorLitteralExpr());
+        values.push_back(ParseTensorLiteralExpr());
         if (!values.back())
           return nullptr; // parse error in the nested array.
       } else {
@@ -236,7 +236,7 @@ private:
     case '(':
       return ParseParenExpr();
     case '[':
-      return ParseTensorLitteralExpr();
+      return ParseTensorLiteralExpr();
     case ';':
       return nullptr;
     case '}':

--- a/examples/toy/Ch2/mlir/MLIRGen.cpp
+++ b/examples/toy/Ch2/mlir/MLIRGen.cpp
@@ -91,7 +91,7 @@ private:
   mlir::ModuleOp theModule;
 
   /// The builder is a helper class to create IR inside a function. The builder
-  /// is stateful, in particular it keeeps an "insertion point": this is where
+  /// is stateful, in particular it keeps an "insertion point": this is where
   /// the next operations will be introduced.
   mlir::OpBuilder builder;
 

--- a/examples/toy/Ch2/parser/AST.cpp
+++ b/examples/toy/Ch2/parser/AST.cpp
@@ -125,7 +125,7 @@ void ASTDumper::dump(NumberExprAST *num) {
   llvm::errs() << num->getValue() << " " << loc(num) << "\n";
 }
 
-/// Helper to print recurisvely a literal. This handles nested array like:
+/// Helper to print recursively a literal. This handles nested array like:
 ///    [ [ 1, 2 ], [ 3, 4 ] ]
 /// We print out such array with the dimensions spelled out at every level:
 ///    <2,2>[<2>[ 1, 2 ], <2>[ 3, 4 ] ]

--- a/examples/toy/Ch3/include/toy/Parser.h
+++ b/examples/toy/Ch3/include/toy/Parser.h
@@ -97,7 +97,7 @@ private:
   /// Parse a literal array expression.
   /// tensorLiteral ::= [ literalList ] | number
   /// literalList ::= tensorLiteral | tensorLiteral, literalList
-  std::unique_ptr<ExprAST> ParseTensorLitteralExpr() {
+  std::unique_ptr<ExprAST> ParseTensorLiteralExpr() {
     auto loc = lexer.getLastLocation();
     lexer.consume(Token('['));
 
@@ -108,7 +108,7 @@ private:
     do {
       // We can have either another nested array or a number literal.
       if (lexer.getCurToken() == '[') {
-        values.push_back(ParseTensorLitteralExpr());
+        values.push_back(ParseTensorLiteralExpr());
         if (!values.back())
           return nullptr; // parse error in the nested array.
       } else {
@@ -236,7 +236,7 @@ private:
     case '(':
       return ParseParenExpr();
     case '[':
-      return ParseTensorLitteralExpr();
+      return ParseTensorLiteralExpr();
     case ';':
       return nullptr;
     case '}':

--- a/examples/toy/Ch3/mlir/MLIRGen.cpp
+++ b/examples/toy/Ch3/mlir/MLIRGen.cpp
@@ -91,7 +91,7 @@ private:
   mlir::ModuleOp theModule;
 
   /// The builder is a helper class to create IR inside a function. The builder
-  /// is stateful, in particular it keeeps an "insertion point": this is where
+  /// is stateful, in particular it keeps an "insertion point": this is where
   /// the next operations will be introduced.
   mlir::OpBuilder builder;
 

--- a/examples/toy/Ch4/include/toy/Parser.h
+++ b/examples/toy/Ch4/include/toy/Parser.h
@@ -97,7 +97,7 @@ private:
   /// Parse a literal array expression.
   /// tensorLiteral ::= [ literalList ] | number
   /// literalList ::= tensorLiteral | tensorLiteral, literalList
-  std::unique_ptr<ExprAST> ParseTensorLitteralExpr() {
+  std::unique_ptr<ExprAST> ParseTensorLiteralExpr() {
     auto loc = lexer.getLastLocation();
     lexer.consume(Token('['));
 
@@ -108,7 +108,7 @@ private:
     do {
       // We can have either another nested array or a number literal.
       if (lexer.getCurToken() == '[') {
-        values.push_back(ParseTensorLitteralExpr());
+        values.push_back(ParseTensorLiteralExpr());
         if (!values.back())
           return nullptr; // parse error in the nested array.
       } else {
@@ -236,7 +236,7 @@ private:
     case '(':
       return ParseParenExpr();
     case '[':
-      return ParseTensorLitteralExpr();
+      return ParseTensorLiteralExpr();
     case ';':
       return nullptr;
     case '}':

--- a/examples/toy/Ch4/parser/AST.cpp
+++ b/examples/toy/Ch4/parser/AST.cpp
@@ -125,7 +125,7 @@ void ASTDumper::dump(NumberExprAST *num) {
   llvm::errs() << num->getValue() << " " << loc(num) << "\n";
 }
 
-/// Helper to print recurisvely a literal. This handles nested array like:
+/// Helper to print recursively a literal. This handles nested array like:
 ///    [ [ 1, 2 ], [ 3, 4 ] ]
 /// We print out such array with the dimensions spelled out at every level:
 ///    <2,2>[<2>[ 1, 2 ], <2>[ 3, 4 ] ]

--- a/examples/toy/Ch5/include/toy/Parser.h
+++ b/examples/toy/Ch5/include/toy/Parser.h
@@ -97,7 +97,7 @@ private:
   /// Parse a literal array expression.
   /// tensorLiteral ::= [ literalList ] | number
   /// literalList ::= tensorLiteral | tensorLiteral, literalList
-  std::unique_ptr<ExprAST> ParseTensorLitteralExpr() {
+  std::unique_ptr<ExprAST> ParseTensorLiteralExpr() {
     auto loc = lexer.getLastLocation();
     lexer.consume(Token('['));
 
@@ -108,7 +108,7 @@ private:
     do {
       // We can have either another nested array or a number literal.
       if (lexer.getCurToken() == '[') {
-        values.push_back(ParseTensorLitteralExpr());
+        values.push_back(ParseTensorLiteralExpr());
         if (!values.back())
           return nullptr; // parse error in the nested array.
       } else {
@@ -236,7 +236,7 @@ private:
     case '(':
       return ParseParenExpr();
     case '[':
-      return ParseTensorLitteralExpr();
+      return ParseTensorLiteralExpr();
     case ';':
       return nullptr;
     case '}':

--- a/examples/toy/Ch5/mlir/MLIRGen.cpp
+++ b/examples/toy/Ch5/mlir/MLIRGen.cpp
@@ -91,7 +91,7 @@ private:
   mlir::ModuleOp theModule;
 
   /// The builder is a helper class to create IR inside a function. The builder
-  /// is stateful, in particular it keeeps an "insertion point": this is where
+  /// is stateful, in particular it keeps an "insertion point": this is where
   /// the next operations will be introduced.
   mlir::OpBuilder builder;
 

--- a/examples/toy/Ch5/parser/AST.cpp
+++ b/examples/toy/Ch5/parser/AST.cpp
@@ -125,7 +125,7 @@ void ASTDumper::dump(NumberExprAST *num) {
   llvm::errs() << num->getValue() << " " << loc(num) << "\n";
 }
 
-/// Helper to print recurisvely a literal. This handles nested array like:
+/// Helper to print recursively a literal. This handles nested array like:
 ///    [ [ 1, 2 ], [ 3, 4 ] ]
 /// We print out such array with the dimensions spelled out at every level:
 ///    <2,2>[<2>[ 1, 2 ], <2>[ 3, 4 ] ]

--- a/g3doc/DeclarativeRewrites.md
+++ b/g3doc/DeclarativeRewrites.md
@@ -373,7 +373,7 @@ def : Pat<(OneAttrOp $attr),
           (TwoAttrOp (getNthAttr<0>:$attr), (getNthAttr<1>:$attr)>;
 ```
 
-In the above, `$_self` is substitutated by the attribute bound by `$attr`, which
+In the above, `$_self` is substituted by the attribute bound by `$attr`, which
 is `OnAttrOp`'s array attribute.
 
 Positional placeholders will be substituted by the `dag` object parameters at

--- a/g3doc/OpDefinitions.md
+++ b/g3doc/OpDefinitions.md
@@ -117,7 +117,7 @@ window in `value`.
     Confined<I64ArrayAttr, [ArrayMinCount<4>]>:$ksize,
     Confined<I64ArrayAttr, [ArrayMinCount<4>]>:$strides,
     TF_AnyStrAttrOf<["SAME", "VALID"]>:$padding,
-    DefaultValuedAttr<TF_ConvnetDataFormatAttr, "NHWC">:$data_format
+    DefaultValuedAttr<TF_ConvertDataFormatAttr, "NHWC">:$data_format
   );
 
   let results = (outs

--- a/test/APITest.h
+++ b/test/APITest.h
@@ -45,7 +45,7 @@ struct TestRegistration {
 } // end namespace test_detail
 
 /// Declares a test function with the given name and adds it to the list of
-/// known tets.  The body of the function must follow immediately.  Example:
+/// known tests.  The body of the function must follow immediately.  Example:
 ///
 /// TEST_FUNC(mytest) {
 ///   // CHECK: expected-output-here

--- a/test/Dialect/FxpMathOps/lower-uniform-real-math-mulew.mlir
+++ b/test/Dialect/FxpMathOps/lower-uniform-real-math-mulew.mlir
@@ -88,7 +88,7 @@ func @real_mulew_unquantized_result(%arg0 : !type_lhs, %arg1: !type_rhs) -> !typ
 !type_rhs = type tensor<4x!quant.uniform<i8:f32, 3.875e-2>>
 !type_result = type tensor<4x!quant.uniform<i8:f32, 1.065e-4>>
 func @real_mulew_multiplier_gt_1(%arg0 : !type_lhs, %arg1: !type_rhs) -> !type_result {
-  // expected-warning@+1 {{unimplemented: cannot multiply with multipler > 1.0}}
+  // expected-warning@+1 {{unimplemented: cannot multiply with multiplier > 1.0}}
   %0 = "fxpmath.real_mul_ew"(%arg0, %arg1) : (!type_lhs, !type_rhs) -> (!type_result)
   return %0 : !type_result
 }

--- a/test/Dialect/FxpMathOps/lower-uniform-real-math-mulew.mlir
+++ b/test/Dialect/FxpMathOps/lower-uniform-real-math-mulew.mlir
@@ -88,7 +88,7 @@ func @real_mulew_unquantized_result(%arg0 : !type_lhs, %arg1: !type_rhs) -> !typ
 !type_rhs = type tensor<4x!quant.uniform<i8:f32, 3.875e-2>>
 !type_result = type tensor<4x!quant.uniform<i8:f32, 1.065e-4>>
 func @real_mulew_multiplier_gt_1(%arg0 : !type_lhs, %arg1: !type_rhs) -> !type_result {
-  // expected-warning@+1 {{unimplemented: cannot multiply with multiplier > 1.0}}
+  // expected-warning@+1 {{unimplemented: cannot multiply with multipler > 1.0}}
   %0 = "fxpmath.real_mul_ew"(%arg0, %arg1) : (!type_lhs, !type_rhs) -> (!type_result)
   return %0 : !type_result
 }

--- a/test/Dialect/GPU/invalid.mlir
+++ b/test/Dialect/GPU/invalid.mlir
@@ -166,7 +166,7 @@ module attributes {gpu.container_module} {
   module @kernels {
   }
 
-  func @launch_func_missing_module_attirbute(%sz : index) {
+  func @launch_func_missing_module_attribute(%sz : index) {
     // expected-error@+1 {{module 'kernels' is missing the 'gpu.kernel_module' attribute}}
     "gpu.launch_func"(%sz, %sz, %sz, %sz, %sz, %sz)
     { kernel = "kernel_1", kernel_module = @kernels }

--- a/test/Dialect/LLVMIR/invalid.mlir
+++ b/test/Dialect/LLVMIR/invalid.mlir
@@ -162,7 +162,7 @@ func @insertvalue_non_array_position() {
 
 // -----
 
-func @insertvlaue_non_integer_position() {
+func @insertvalue_non_integer_position() {
   // expected-error@+1 {{expected an array of integer literals}}
   llvm.insertvalue %a, %b[0.0] : !llvm<"{i32}">
 }
@@ -206,7 +206,7 @@ func @extractvalue_non_array_position() {
 
 // -----
 
-func @extractvlaue_non_integer_position() {
+func @extractvalue_non_integer_position() {
   // expected-error@+1 {{expected an array of integer literals}}
   llvm.extractvalue %b[0.0] : !llvm<"{i32}">
 }

--- a/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/test/Dialect/LLVMIR/roundtrip.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: func @ops(%arg0: !llvm.i32, %arg1: !llvm.float)
 func @ops(%arg0 : !llvm.i32, %arg1 : !llvm.float) {
-// Integer artithmetics binary operations.
+// Integer arithmetic binary operations.
 //
 // CHECK-NEXT:  %0 = llvm.add %arg0, %arg0 : !llvm.i32
 // CHECK-NEXT:  %1 = llvm.sub %arg0, %arg0 : !llvm.i32

--- a/test/Dialect/SPIRV/control-flow-ops.mlir
+++ b/test/Dialect/SPIRV/control-flow-ops.mlir
@@ -108,7 +108,7 @@ func @wrong_accessor_count() -> () {
 
 // -----
 
-func @accessor_argment_disallowed() -> () {
+func @accessor_argument_disallowed() -> () {
   %true = spv.constant true
   // expected-error @+1 {{requires a single operand}}
   "spv.BranchConditional"(%true)[^one(%true : i1), ^two] : (i1) -> ()

--- a/test/Dialect/SPIRV/structure-ops.mlir
+++ b/test/Dialect/SPIRV/structure-ops.mlir
@@ -268,7 +268,7 @@ spv.module "Logical" "GLSL450" { } attributes {
   extension = ["SPV_KHR_16bit_storage"]
 }
 
-// Module with explict spv._module_end
+// Module with explicit spv._module_end
 // CHECK: spv.module
 spv.module "Logical" "GLSL450" {
   spv._module_end

--- a/test/Dialect/SPIRV/types.mlir
+++ b/test/Dialect/SPIRV/types.mlir
@@ -189,7 +189,7 @@ func @image_parameters_six_elements(!spv.image<f32, 1D, NoDepth, NonArrayed, Sin
 // -----
 
 // expected-error @+1 {{spv.image delimiter <...> mismatch}}
-func @image_parameters_delimiter(!spv.image f32, 1D, NoDepth, NonArrayed, SingleSampled, SamplerUnknown, Unkown>) -> ()
+func @image_parameters_delimiter(!spv.image f32, 1D, NoDepth, NonArrayed, SingleSampled, SamplerUnknown, Unknown>) -> ()
 
 // -----
 

--- a/test/IR/affine-map.mlir
+++ b/test/IR/affine-map.mlir
@@ -167,7 +167,7 @@
 // CHECK: #map{{[0-9]+}} = (d0) -> (-2, 1, -1)
 #map51 = (i) -> (-5 floordiv 3, -5 mod 3, -5 ceildiv 3)
 
-// Parenthesis ellision.
+// Parenthesis elision.
 // CHECK: #map{{[0-9]+}} = (d0) -> (d0 * 16 - (d0 + 1) + 15)
 #map52 = (d0) -> (16*d0 + ((d0 + 1) * -1) + 15)
 

--- a/test/IR/parser.mlir
+++ b/test/IR/parser.mlir
@@ -960,7 +960,7 @@ func @f16_special_values() {
   // F16 positive infinity.
   // CHECK: constant 0x7C00 : f16
   %3 = constant 0x7C00 : f16
-  // F16 negative inifinity.
+  // F16 negative infinity.
   // CHECK: constant 0xFC00 : f16
   %4 = constant 0xFC00 : f16
 
@@ -1005,7 +1005,7 @@ func @f64_special_values() {
   // CHECK: constant 0xFFF0000001000000 : f64
   %3 = constant 0xFFF0000001000000 : f64
 
-  // F64 positive inifinity.
+  // F64 positive infinity.
   // CHECK: constant 0x7FF0000000000000 : f64
   %4 = constant 0x7FF0000000000000 : f64
   // F64 negative infinity.

--- a/test/SDBM/sdbm-api-test.cpp
+++ b/test/SDBM/sdbm-api-test.cpp
@@ -83,7 +83,7 @@ TEST_FUNC(SDBM_TrivialSimplification) {
   //   d0 - 3 <= 0  <=>  d0 <= 3
   //   d0 - 5 <= 0  <=>  d0 <= 5
   //
-  // which should get simplifed on construction to only the former.
+  // which should get simplified on construction to only the former.
   auto sdbm = SDBM::get({dim(0) - 3, dim(0) - 5}, llvm::None);
 
   //      CHECK:       cst   d0

--- a/test/Transforms/loop-fusion.mlir
+++ b/test/Transforms/loop-fusion.mlir
@@ -1485,7 +1485,7 @@ func @should_fuse_at_depth_above_loop_carried_dependence(%arg0: memref<64x4xf32>
   // depth at which we can insert the src loop nest slice into the dst loop
   // lest must be decreased because of a loop carried dependence on loop '%i3'.
   // As a result, the source loop nest is inserted at dst loop nest depth 1,
-  // just above the loop with the carried depenence. In addition, the source
+  // just above the loop with the carried dependence. In addition, the source
   // loop nest iteration bounds on its loop '%i1' are reduced to 1, so the
   // memref size can be reduced to 128x1xf32.
 
@@ -2185,7 +2185,7 @@ func @affine_2mm_fused(%arg0: memref<1024x1024xf32>, %arg1: memref<1024x1024xf32
     }
   }
 
-  // Should fuse MM intialization loops into their consumers, then fuse the
+  // Should fuse MM initialization loops into their consumers, then fuse the
   // two matmul loops together for input reuse on '%arg0/%arg1'.
 
   // CHECK:        affine.for %{{.*}} = 0 to 1024 {

--- a/test/Transforms/parametric-tiling.mlir
+++ b/test/Transforms/parametric-tiling.mlir
@@ -84,7 +84,7 @@ func @triangular(%arg0: memref<?x?xf32>) {
   // New outer step (original is %c1).
   // COMMON-NEXT:  %[[step:.*]] = muli %c1, %[[size]]
 
-  // Constant adjustement for inner loop has been hoisted out.
+  // Constant adjustment for inner loop has been hoisted out.
   // TILE_74:      %[[adjustment2:.*]] = subi %c2, %c1_{{.*}}
 
   // New outer loop.

--- a/test/Transforms/simplify-affine-structures.mlir
+++ b/test/Transforms/simplify-affine-structures.mlir
@@ -30,7 +30,7 @@
                              d0 * 7 + d1 * 5 + s0 * 11 + s1 == 0,
                              d0 - 1 == 0, d0 + 2 == 0)
 
-// This is an artifically created system to exercise the worst case behavior of
+// This is an artificially created system to exercise the worst case behavior of
 // FM elimination - as a safeguard against improperly constructed constraint
 // systems or fuzz input.
 #set_fuzz_virus = (d0, d1, d2, d3, d4, d5) : ( 1089234*d0 + 203472*d1 + 82342 >= 0,

--- a/test/lib/TestDialect/TestOps.td
+++ b/test/lib/TestDialect/TestOps.td
@@ -442,14 +442,14 @@ def OpNativeCodeCall2 : TEST_Op<"native_code_call2"> {
 // Native code call to invoke a C++ function
 def CreateOperand: NativeCodeCall<"chooseOperand($0, $1, $2)">;
 // Native code call to invoke a C++ expression
-def CreateArraryAttr: NativeCodeCall<"$_builder.getArrayAttr({$0, $1})">;
+def CreateArrayAttr: NativeCodeCall<"$_builder.getArrayAttr({$0, $1})">;
 // Test that we can use NativeCodeCall to create operand and attribute.
 // This pattern chooses between $input1 and $input2 according to $choice and
 // it combines $attr1 and $attr2 into an array attribute.
 def : Pat<(OpNativeCodeCall1 $input1, $input2,
                              ConstBoolAttrTrue:$choice, $attr1, $attr2),
           (OpNativeCodeCall2 (CreateOperand $input1, $input2, $choice),
-                             (CreateArraryAttr $attr1, $attr2))>;
+                             (CreateArrayAttr $attr1, $attr2))>;
 // Note: the following is just for testing purpose.
 // Should use the replaceWithValue directive instead.
 def UseOpResult: NativeCodeCall<"$0">;
@@ -719,7 +719,7 @@ def OneVResOneVOperandOp2 : TEST_Op<"one_variadic_out_one_variadic_in2"> {
 }
 
 // Rewrite an op with one variadic operand and one variadic result to
-// another similiar op.
+// another similar op.
 def : Pat<(OneVResOneVOperandOp1 $inputs), (OneVResOneVOperandOp2 $inputs)>;
 
 def MixedVOperandOp1 : TEST_Op<"mixed_variadic_in1",

--- a/test/lib/Transforms/TestLoopFusion.cpp
+++ b/test/lib/Transforms/TestLoopFusion.cpp
@@ -129,7 +129,7 @@ static std::string getSliceStr(const mlir::ComputationSliceState &sliceUnion) {
 
 // Computes fusion slice union on 'loops[i]' and 'loops[j]' at loop depths
 // in range ['loopDepth' + 1, 'maxLoopDepth'].
-// Emits a string represention of the slice union as a remark on 'loops[j]'.
+// Emits a string representation of the slice union as a remark on 'loops[j]'.
 static void testSliceComputation(SmallVector<AffineForOp, 2> &loops, unsigned i,
                                  unsigned j, unsigned loopDepth,
                                  unsigned maxLoopDepth) {

--- a/test/mlir-tblgen/op-result.td
+++ b/test/mlir-tblgen/op-result.td
@@ -97,7 +97,7 @@ def OpI : NS_Op<"mix_variadic_and_normal_results_op", [SameVariadicResultSize]> 
 // CHECK-NEXT:    tblgen_state.addTypes(output2);
 // CHECK-NEXT:    tblgen_state.addTypes(output3);
 
-// Test that if the only operand is variadic, we acess the first value in the
+// Test that if the only operand is variadic, we access the first value in the
 // pack to set result type
 // ---
 def OpK : NS_Op<"only_input_is_variadic_with_same_value_type_op", [SameOperandsAndResultType]> {

--- a/test/mlir-tblgen/pattern.mlir
+++ b/test/mlir-tblgen/pattern.mlir
@@ -168,7 +168,7 @@ func @verifyI64EnumAttr() -> i32 {
 }
 
 //===----------------------------------------------------------------------===//
-// Test ElelementsAttr
+// Test ElementsAttr
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: rewrite_i32elementsattr
@@ -302,8 +302,8 @@ func @replaceMixedVariadicOutputOp() -> (f32, i32, f32, i32, i32, i32, f32, i32,
   return %0, %1#0, %1#1, %1#2, %2#0, %2#1, %2#2, %2#3, %2#4 : f32, i32, f32, i32, i32, i32, f32, i32, i32
 }
 
-// CHECK-LABEL: @generateVaridicOutputOpInNestedPattern
-func @generateVaridicOutputOpInNestedPattern() -> (i32) {
+// CHECK-LABEL: @generateVariadicOutputOpInNestedPattern
+func @generateVariadicOutputOpInNestedPattern() -> (i32) {
   // CHECK: %[[cnt5:.*]]:5 = "test.mixed_variadic_out3"()
   // CHECK: %[[res:.*]] = "test.mixed_variadic_in3"(%[[cnt5]]#0, %[[cnt5]]#1, %[[cnt5]]#2, %[[cnt5]]#3, %[[cnt5]]#4)
   // CHECK: return %[[res]]

--- a/unittests/Dialect/SPIRV/SerializationTest.cpp
+++ b/unittests/Dialect/SPIRV/SerializationTest.cpp
@@ -1,4 +1,4 @@
-//===- SerializationTest.cpp - SPIR-V Serialization Tests -------------===//
+//===- SerializationTest.cpp - SPIR-V Serialization Tests -----------------===//
 //
 // Copyright 2019 The MLIR Authors.
 //

--- a/unittests/Dialect/SPIRV/SerializationTest.cpp
+++ b/unittests/Dialect/SPIRV/SerializationTest.cpp
@@ -1,4 +1,4 @@
-//===- SerializationTest.cpp - SPIR-V Seserialization Tests -------------===//
+//===- SerializationTest.cpp - SPIR-V Serialization Tests -------------===//
 //
 // Copyright 2019 The MLIR Authors.
 //

--- a/unittests/SDBM/SDBMTest.cpp
+++ b/unittests/SDBM/SDBMTest.cpp
@@ -219,7 +219,7 @@ TEST(SDBM, RoundTripEqs) {
 }
 
 TEST(SDBMExpr, Constant) {
-  // We can create consants and query them.
+  // We can create constants and query them.
   auto expr = SDBMConstantExpr::get(dialect(), 42);
   EXPECT_EQ(expr.getValue(), 42);
 

--- a/unittests/TableGen/structs.td
+++ b/unittests/TableGen/structs.td
@@ -1,4 +1,4 @@
-//===-- structss.td - StructsGen test definition file ------*- tablegen -*-===//
+//===-- structs.td - StructsGen test definition file ------*- tablegen -*-===//
 //
 // Copyright 2019 The MLIR Authors.
 //

--- a/unittests/TableGen/structs.td
+++ b/unittests/TableGen/structs.td
@@ -1,4 +1,4 @@
-//===-- structs.td - StructsGen test definition file ------*- tablegen -*-===//
+//===-- structs.td - StructsGen test definition file -------*- tablegen -*-===//
 //
 // Copyright 2019 The MLIR Authors.
 //

--- a/utils/generate-test-checks.py
+++ b/utils/generate-test-checks.py
@@ -51,7 +51,7 @@ class SSAVariableNamer:
     self.scopes = []
     self.name_counter = 0
 
-  # Generate a subsitution name for the given ssa value name.
+  # Generate a substitution name for the given ssa value name.
   def generate_name(self, ssa_name):
     variable = 'VAL_' + str(self.name_counter)
     self.name_counter += 1

--- a/utils/spirv/gen_spirv_dialect.py
+++ b/utils/spirv/gen_spirv_dialect.py
@@ -343,7 +343,7 @@ def map_spec_operand_to_ods_argument(operand):
       arg_type = 'Variadic<SPV_Type>'
   elif kind == 'IdMemorySemantics' or kind == 'IdScope':
     # TODO(antiagainst): Need to further constrain 'IdMemorySemantics'
-    # and 'IdScope' given that they should be gerenated from OpConstant.
+    # and 'IdScope' given that they should be generated from OpConstant.
     assert quantifier == '', ('unexpected to have optional/variadic memory '
                               'semantics or scope <id>')
     arg_type = 'I32'

--- a/utils/spirv/gen_spirv_dialect.py
+++ b/utils/spirv/gen_spirv_dialect.py
@@ -311,7 +311,7 @@ def update_td_enum_attrs(path, operand_kinds, filter_list):
 
 
 def snake_casify(name):
-  """Turns the given name to follow snake_case convension."""
+  """Turns the given name to follow snake_case convention."""
   name = re.sub('\W+', '', name).split()
   name = [s.lower() for s in name]
   return '_'.join(name)
@@ -343,7 +343,7 @@ def map_spec_operand_to_ods_argument(operand):
       arg_type = 'Variadic<SPV_Type>'
   elif kind == 'IdMemorySemantics' or kind == 'IdScope':
     # TODO(antiagainst): Need to further constrain 'IdMemorySemantics'
-    # and 'IdScope' given that they should be gernated from OpConstant.
+    # and 'IdScope' given that they should be gerenated from OpConstant.
     assert quantifier == '', ('unexpected to have optional/variadic memory '
                               'semantics or scope <id>')
     arg_type = 'I32'


### PR DESCRIPTION
This PR addresses spelling tweaks under bindings, examples, g3doc,  test, unittests, and utils directories.   
Another PR will address spelling tweaks in other directories.