### PR TITLE
minor spelling tweaks under include and tools

### DIFF
--- a/include/mlir/Analysis/AffineStructures.h
+++ b/include/mlir/Analysis/AffineStructures.h
@@ -677,7 +677,7 @@ public:
   /// constraints, does a single scan, and updates in place.
   void removeTrivialRedundancy();
 
-  /// A more expensive check to detect redundant inequalities than
+  /// A more expensive check to detect redundant inequalities thatn
   /// removeTrivialRedundancy.
   void removeRedundantInequalities();
 

--- a/include/mlir/Analysis/AffineStructures.h
+++ b/include/mlir/Analysis/AffineStructures.h
@@ -188,7 +188,7 @@ class IntegerValueSet {
   /// Returns true if this integer set is determined to be empty. Emptiness is
   /// checked by by eliminating identifiers successively (through either
   /// Gaussian or Fourier-Motzkin) while using the GCD test and a trivial
-  /// invalid constraint check. Returns 'true' if the constaint system is found
+  /// invalid constraint check. Returns 'true' if the constraint system is found
   /// to be empty; false otherwise. This method is exact for rational spaces but
   /// not integer spaces - thus, if it returns true, the set is provably integer
   /// empty as well, but if it returns false, it doesn't necessarily mean an
@@ -677,7 +677,7 @@ public:
   /// constraints, does a single scan, and updates in place.
   void removeTrivialRedundancy();
 
-  /// A more expensive check to detect redundant inequalities thatn
+  /// A more expensive check to detect redundant inequalities than
   /// removeTrivialRedundancy.
   void removeRedundantInequalities();
 

--- a/include/mlir/Analysis/CallGraph.h
+++ b/include/mlir/Analysis/CallGraph.h
@@ -220,7 +220,7 @@ private:
 } // end namespace mlir
 
 namespace llvm {
-// Provide graph traits for tranversing call graphs using standard graph
+// Provide graph traits for traversing call graphs using standard graph
 // traversals.
 template <> struct GraphTraits<const mlir::CallGraphNode *> {
   using NodeRef = mlir::CallGraphNode *;

--- a/include/mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h
+++ b/include/mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h
@@ -1,4 +1,4 @@
-//===- GPUToNVMMPass.h - Convert GPU kernel to NVVM dialect -----*- C++ -*-===//
+//===- GPUToNVVMPass.h - Convert GPU kernel to NVVM dialect -----*- C++ -*-===//
 //
 // Copyright 2019 The MLIR Authors.
 //

--- a/include/mlir/Dialect/AffineOps/AffineOps.h
+++ b/include/mlir/Dialect/AffineOps/AffineOps.h
@@ -109,7 +109,7 @@ public:
 /// affine expression of loop induction variables and symbols.
 /// The optional stride arguments should be of 'index' type, and specify a
 /// stride for the slower memory space (memory space with a lower memory space
-/// id), tranferring chunks of number_of_elements_per_stride every stride until
+/// id), transferring chunks of number_of_elements_per_stride every stride until
 /// %num_elements are transferred. Either both or no stride arguments should be
 /// specified. The value of 'num_elements' must be a multiple of
 /// 'number_of_elements_per_stride'.

--- a/include/mlir/Dialect/FxpMathOps/FxpMathOps.td
+++ b/include/mlir/Dialect/FxpMathOps/FxpMathOps.td
@@ -177,7 +177,7 @@ def fxpmath_RoundingDivideByPotISOp :
 //
 // Math ops on real numbers which may have a representation in quantized
 // arithmetic. It is expected that eligible ops are lowered from a source
-// dialect to this set of ops prior to the process of converting a compuation
+// dialect to this set of ops prior to the process of converting a computation
 // to a quantized form. It is a non-goal of these ops to preserve enough
 // information to convert back to the higher level, source dialect.
 //

--- a/include/mlir/Dialect/SDBM/SDBMExpr.h
+++ b/include/mlir/Dialect/SDBM/SDBMExpr.h
@@ -434,7 +434,7 @@ protected:
   }
 
   /// Default implementation of visitVarying dispatches to the special
-  /// functions for variables and negations thereof.  Concerete visitors can
+  /// functions for variables and negations thereof.  Concrete visitors can
   /// override it to visit all variables and negations instead.
   Result visitVarying(SDBMVaryingExpr expr) {
     auto *derived = static_cast<Derived *>(this);

--- a/include/mlir/Dialect/SPIRV/SPIRVBase.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVBase.td
@@ -241,7 +241,7 @@ def SPV_AnyStruct : Type<SPV_IsStructType, "any SPIR-V struct type">;
 
 def SPV_Numerical : AnyTypeOf<[SPV_Integer, SPV_Float]>;
 def SPV_Scalar : AnyTypeOf<[SPV_Numerical, SPV_Bool]>;
-def SPV_Aggregrate : AnyTypeOf<[SPV_AnyArray, SPV_AnyStruct]>;
+def SPV_Aggregate : AnyTypeOf<[SPV_AnyArray, SPV_AnyStruct]>;
 def SPV_Composite :
     AnyTypeOf<[SPV_Vector, SPV_AnyArray, SPV_AnyRTArray, SPV_AnyStruct]>;
 def SPV_Type : AnyTypeOf<[

--- a/include/mlir/Dialect/SPIRV/SPIRVGLSLOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVGLSLOps.td
@@ -56,9 +56,9 @@ class SPV_GLSLUnaryOp<string mnemonic, int opcode, Type resultType,
   let verifier = [{ return success(); }];
 }
 
-// Base class for GLSL Unary arithmatic ops where return type matches
+// Base class for GLSL Unary arithmetic ops where return type matches
 // the operand type.
-class SPV_GLSLUnaryArithmaticOp<string mnemonic, int opcode, Type type,
+class SPV_GLSLUnaryArithmeticOp<string mnemonic, int opcode, Type type,
                                 list<OpTrait> traits = []> :
   SPV_GLSLUnaryOp<mnemonic, opcode, type, type, traits>;
 
@@ -83,15 +83,15 @@ class SPV_GLSLBinaryOp<string mnemonic, int opcode, Type resultType,
   let verifier = [{ return success(); }];
 }
 
-// Base class for GLSL Binary arithmatic ops where operand types and
+// Base class for GLSL Binary arithmetic ops where operand types and
 // return type matches.
-class SPV_GLSLBinaryArithmaticOp<string mnemonic, int opcode, Type type,
+class SPV_GLSLBinaryArithmeticOp<string mnemonic, int opcode, Type type,
                                  list<OpTrait> traits = []> :
   SPV_GLSLBinaryOp<mnemonic, opcode, type, type, traits>;
 
 // -----
 
-def SPV_GLSLFAbsOp : SPV_GLSLUnaryArithmaticOp<"FAbs", 4, SPV_Float> {
+def SPV_GLSLFAbsOp : SPV_GLSLUnaryArithmeticOp<"FAbs", 4, SPV_Float> {
   let summary = "Absolute value of operand";
 
   let description = [{
@@ -121,7 +121,7 @@ def SPV_GLSLFAbsOp : SPV_GLSLUnaryArithmaticOp<"FAbs", 4, SPV_Float> {
 
 // -----
 
-def SPV_GLSLSAbsOp : SPV_GLSLUnaryArithmaticOp<"SAbs", 5, SPV_Integer> {
+def SPV_GLSLSAbsOp : SPV_GLSLUnaryArithmeticOp<"SAbs", 5, SPV_Integer> {
   let summary = "Absolute value of operand";
 
   let description = [{
@@ -150,7 +150,7 @@ def SPV_GLSLSAbsOp : SPV_GLSLUnaryArithmaticOp<"SAbs", 5, SPV_Integer> {
 
 // -----
 
-def SPV_GLSLCeilOp : SPV_GLSLUnaryArithmaticOp<"Ceil", 9, SPV_Float> {
+def SPV_GLSLCeilOp : SPV_GLSLUnaryArithmeticOp<"Ceil", 9, SPV_Float> {
   let summary = "Rounds up to the next whole number";
 
   let description = [{
@@ -181,7 +181,7 @@ def SPV_GLSLCeilOp : SPV_GLSLUnaryArithmaticOp<"Ceil", 9, SPV_Float> {
 
 // -----
 
-def SPV_GLSLCosOp : SPV_GLSLUnaryArithmaticOp<"Cos", 14, SPV_Float16or32> {
+def SPV_GLSLCosOp : SPV_GLSLUnaryArithmeticOp<"Cos", 14, SPV_Float16or32> {
   let summary = "Cosine of operand in radians";
 
   let description = [{
@@ -213,7 +213,7 @@ def SPV_GLSLCosOp : SPV_GLSLUnaryArithmaticOp<"Cos", 14, SPV_Float16or32> {
 
 // -----
 
-def SPV_GLSLExpOp : SPV_GLSLUnaryArithmaticOp<"Exp", 27, SPV_Float16or32> {
+def SPV_GLSLExpOp : SPV_GLSLUnaryArithmeticOp<"Exp", 27, SPV_Float16or32> {
   let summary = "Exponentiation of Operand 1";
 
   let description = [{
@@ -245,7 +245,7 @@ def SPV_GLSLExpOp : SPV_GLSLUnaryArithmaticOp<"Exp", 27, SPV_Float16or32> {
 
 // -----
 
-def SPV_GLSLFloorOp : SPV_GLSLUnaryArithmaticOp<"Floor", 8, SPV_Float> {
+def SPV_GLSLFloorOp : SPV_GLSLUnaryArithmeticOp<"Floor", 8, SPV_Float> {
   let summary = "Rounds down to the next whole number";
 
   let description = [{
@@ -276,7 +276,7 @@ def SPV_GLSLFloorOp : SPV_GLSLUnaryArithmaticOp<"Floor", 8, SPV_Float> {
 
 // -----
 
-def SPV_GLSLInverseSqrtOp : SPV_GLSLUnaryArithmaticOp<"InverseSqrt", 32, SPV_Float> {
+def SPV_GLSLInverseSqrtOp : SPV_GLSLUnaryArithmeticOp<"InverseSqrt", 32, SPV_Float> {
   let summary = "Reciprocal of sqrt(operand)";
 
   let description = [{
@@ -306,7 +306,7 @@ def SPV_GLSLInverseSqrtOp : SPV_GLSLUnaryArithmaticOp<"InverseSqrt", 32, SPV_Flo
 
 // -----
 
-def SPV_GLSLLogOp : SPV_GLSLUnaryArithmaticOp<"Log", 28, SPV_Float16or32> {
+def SPV_GLSLLogOp : SPV_GLSLUnaryArithmeticOp<"Log", 28, SPV_Float16or32> {
   let summary = "Natural logarithm of the operand";
 
   let description = [{
@@ -339,7 +339,7 @@ def SPV_GLSLLogOp : SPV_GLSLUnaryArithmaticOp<"Log", 28, SPV_Float16or32> {
 
 // -----
 
-def SPV_GLSLFMaxOp : SPV_GLSLBinaryArithmaticOp<"FMax", 40, SPV_Float> {
+def SPV_GLSLFMaxOp : SPV_GLSLBinaryArithmeticOp<"FMax", 40, SPV_Float> {
   let summary = "Return maximum of two floating-point operands";
 
   let description = [{
@@ -370,7 +370,7 @@ def SPV_GLSLFMaxOp : SPV_GLSLBinaryArithmaticOp<"FMax", 40, SPV_Float> {
 
 // -----
 
-def SPV_GLSLSMaxOp : SPV_GLSLBinaryArithmaticOp<"SMax", 42, SPV_Integer> {
+def SPV_GLSLSMaxOp : SPV_GLSLBinaryArithmeticOp<"SMax", 42, SPV_Integer> {
   let summary = "Return maximum of two signed integer operands";
 
   let description = [{
@@ -400,7 +400,7 @@ def SPV_GLSLSMaxOp : SPV_GLSLBinaryArithmaticOp<"SMax", 42, SPV_Integer> {
 
 // -----
 
-def SPV_GLSLFMinOp : SPV_GLSLBinaryArithmaticOp<"FMin", 37, SPV_Float> {
+def SPV_GLSLFMinOp : SPV_GLSLBinaryArithmeticOp<"FMin", 37, SPV_Float> {
   let summary = "Return minimum of two floating-point operands";
 
   let description = [{
@@ -431,7 +431,7 @@ def SPV_GLSLFMinOp : SPV_GLSLBinaryArithmaticOp<"FMin", 37, SPV_Float> {
 
 // -----
 
-def SPV_GLSLSMinOp : SPV_GLSLBinaryArithmaticOp<"SMin", 39, SPV_Integer> {
+def SPV_GLSLSMinOp : SPV_GLSLBinaryArithmeticOp<"SMin", 39, SPV_Integer> {
   let summary = "Return minimum of two signed integer operands";
 
   let description = [{
@@ -461,7 +461,7 @@ def SPV_GLSLSMinOp : SPV_GLSLBinaryArithmaticOp<"SMin", 39, SPV_Integer> {
 
 // -----
 
-def SPV_GLSLFSignOp : SPV_GLSLUnaryArithmaticOp<"FSign", 6, SPV_Float> {
+def SPV_GLSLFSignOp : SPV_GLSLUnaryArithmeticOp<"FSign", 6, SPV_Float> {
   let summary = "Returns the sign of the operand";
 
   let description = [{
@@ -491,7 +491,7 @@ def SPV_GLSLFSignOp : SPV_GLSLUnaryArithmaticOp<"FSign", 6, SPV_Float> {
 
 // -----
 
-def SPV_GLSLSSignOp : SPV_GLSLUnaryArithmaticOp<"SSign", 7, SPV_Integer> {
+def SPV_GLSLSSignOp : SPV_GLSLUnaryArithmeticOp<"SSign", 7, SPV_Integer> {
   let summary = "Returns the sign of the operand";
 
   let description = [{
@@ -520,7 +520,7 @@ def SPV_GLSLSSignOp : SPV_GLSLUnaryArithmaticOp<"SSign", 7, SPV_Integer> {
 
 // -----
 
-def SPV_GLSLTanhOp : SPV_GLSLUnaryArithmaticOp<"Tanh", 21, SPV_Float16or32> {
+def SPV_GLSLTanhOp : SPV_GLSLUnaryArithmeticOp<"Tanh", 21, SPV_Float16or32> {
   let summary = "Hyperbolic tangent of operand in radians";
 
   let description = [{

--- a/include/mlir/Dialect/SPIRV/SPIRVStructureOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVStructureOps.td
@@ -89,7 +89,7 @@ def SPV_ConstantOp : SPV_Op<"constant", [NoSideEffect]> {
     more tedious. Therefore, we use a single `spv.constant` op to represent
     them all. Note that conversion between those SPIR-V constant instructions
     and this op is purely mechanical; so it can be scoped to the binary
-    (de)serialzation process.
+    (de)serialization process.
 
     ### Custom assembly form
 
@@ -267,7 +267,7 @@ def SPV_ModuleOp : SPV_Op<"module",
 
     Using an op with a region to define a SPIR-V module enables "embedding"
     SPIR-V modules in other dialects in a clean manner: this op guarantees
-    the validaty and serializability of a SPIR-V module and thus serves as
+    the validity and serializability of a SPIR-V module and thus serves as
     a clear-cut boundary.
 
     This op takes no operands and generates no results. This op should not
@@ -427,7 +427,7 @@ def SPV_SpecConstantOp : SPV_Op<"specConstant", [InModuleScope]> {
     spv.specConstant @spec_const2 = 42 : i32
     ```
 
-    TODO(antiagainst): support composite spec cosntants with another op
+    TODO(antiagainst): support composite spec constants with another op
   }];
 
   let arguments = (ins

--- a/include/mlir/Dialect/SPIRV/Serialization.h
+++ b/include/mlir/Dialect/SPIRV/Serialization.h
@@ -15,7 +15,7 @@
 // limitations under the License.
 // =============================================================================
 //
-// This file declares the entry points for serialize and deserialze SPIR-V
+// This file declares the entry points for serialize and deserialize SPIR-V
 // binary modules.
 //
 //===----------------------------------------------------------------------===//

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -94,7 +94,7 @@ class ArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
 // tensors thereof.  This operation takes two operands and returns one result,
 // each of these is required to be of the same type.  This type may be an
 // integer scalar type, a vector whose element type is an integer type, or an
-// integer tensor.  The custom assembly form of the operaton is as follows
+// integer tensor.  The custom assembly form of the operation is as follows
 //
 //     <op>i %0, %1 : i32
 class IntArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
@@ -773,7 +773,7 @@ def MemRefCastOp : CastOp<"memref_cast"> {
 }
 
 def MulFOp : FloatArithmeticOp<"mulf"> {
-  let summary = "foating point multiplication operation";
+  let summary = "floating point multiplication operation";
   let hasFolder = 1;
 }
 
@@ -1076,7 +1076,7 @@ def TruncateIOp : Std_Op<"trunci", [NoSideEffect, SameOperandsAndResultShape]> {
     The integer truncation operation takes an integer input of
     width M and an integer destination type of width N. The destination
     bit-width must be smaller than the input bit-width (N < M).
-    The top-most (N - M) bits of the input are discareded.
+    The top-most (N - M) bits of the input are discarded.
 
       %1 = constant 21 : i5           // %1 is 0b10101
       %2 = trunci %1 : i5 to i4       // %2 is 0b0101

--- a/include/mlir/Dialect/Traits.h
+++ b/include/mlir/Dialect/Traits.h
@@ -40,7 +40,7 @@ namespace util {
 /// given shapes if they are broadcast compatible. Returns false and clears
 /// `resultShape` otherwise.
 ///
-/// The rules for determing the result shape are:
+/// The rules for determining the result shape are:
 ///
 /// Zip together the dimensions in the two given shapes by prepending the shape
 /// with less dimensions with 1s. For each dimension pair, deduces the result

--- a/include/mlir/EDSC/Intrinsics.h
+++ b/include/mlir/EDSC/Intrinsics.h
@@ -244,7 +244,7 @@ OperationHandle br(BlockHandle *bh, ArrayRef<ValueHandle *> captures,
 /// `falseOperand` if `cond` evaluates to `false`).
 ///
 /// Prerequisites:
-///   Alh Handles have captured previously constructed IR objects.
+///   All Handles have captured previously constructed IR objects.
 OperationHandle cond_br(ValueHandle cond, BlockHandle trueBranch,
                         ArrayRef<ValueHandle> trueOperands,
                         BlockHandle falseBranch,

--- a/include/mlir/EDSC/Intrinsics.h
+++ b/include/mlir/EDSC/Intrinsics.h
@@ -244,7 +244,7 @@ OperationHandle br(BlockHandle *bh, ArrayRef<ValueHandle *> captures,
 /// `falseOperand` if `cond` evaluates to `false`).
 ///
 /// Prerequisites:
-///   All Handles have captured previouly constructed IR objects.
+///   Alh Handles have captured previously constructed IR objects.
 OperationHandle cond_br(ValueHandle cond, BlockHandle trueBranch,
                         ArrayRef<ValueHandle> trueOperands,
                         BlockHandle falseBranch,

--- a/include/mlir/IR/AffineExprVisitor.h
+++ b/include/mlir/IR/AffineExprVisitor.h
@@ -249,7 +249,7 @@ private:
 // to the same operands, for example, for all result expressions of an
 // AffineMap or AffineValueMap. In such cases, using it for multiple expressions
 // is more efficient than creating a new flattener for each expression since
-// common idenical div and mod expressions appearing across different
+// common identical div and mod expressions appearing across different
 // expressions are mapped to the same local identifier (same column position in
 // 'localVarCst').
 class SimpleAffineExprFlattener

--- a/include/mlir/IR/Attributes.h
+++ b/include/mlir/IR/Attributes.h
@@ -508,7 +508,7 @@ public:
   }
 
 protected:
-  /// Returns the 1 dimenional flattened row-major index from the given
+  /// Returns the 1 dimensional flattened row-major index from the given
   /// multi-dimensional index.
   uint64_t getFlattenedIndex(ArrayRef<uint64_t> index) const;
 };
@@ -921,7 +921,7 @@ public:
 };
 
 /// An opaque attribute that represents a reference to a vector or tensor
-/// constant with opaque content. This respresentation is for tensor constants
+/// constant with opaque content. This representation is for tensor constants
 /// which the compiler may not need to interpret. This attribute is always
 /// associated with a particular dialect, which provides a method to convert
 /// tensor representation to a non-opaque format.

--- a/include/mlir/IR/Block.h
+++ b/include/mlir/IR/Block.h
@@ -231,7 +231,7 @@ public:
         : llvm::mapped_iterator<op_filter_iterator<OpT>, OpT (*)(Operation &)>(
               it, &unwrap) {}
 
-    /// Allow implict conversion to the underlying block iterator.
+    /// Allow implicit conversion to the underlying block iterator.
     operator Block::iterator() const { return this->wrapped(); }
   };
 

--- a/include/mlir/IR/FunctionSupport.h
+++ b/include/mlir/IR/FunctionSupport.h
@@ -97,7 +97,7 @@ namespace OpTrait {
 /// - Ops can be used with SymbolTable in the parent Op and have names;
 /// - Ops have a single region with multiple blocks that corresponds to the body
 ///   of the function;
-/// - the absence of a region corresonds to an external function;
+/// - the absence of a region corresponds to an external function;
 /// - arguments of the first block of the region are treated as function
 ///   arguments;
 /// - they can have argument attributes that are stored in a dictionary

--- a/include/mlir/IR/IntegerSet.h
+++ b/include/mlir/IR/IntegerSet.h
@@ -21,7 +21,7 @@
 // other operations. It is typically expected to contain only a handful of
 // affine constraints, and is immutable like an affine map. Integer sets are not
 // unique'd - although affine expressions that make up its equalities and
-// inequalites are themselves unique.
+// inequalities are themselves unique.
 
 // This class is not meant for affine analysis and operations like set
 // operations, emptiness checks, or other math operations for analysis and

--- a/include/mlir/IR/Matchers.h
+++ b/include/mlir/IR/Matchers.h
@@ -36,7 +36,7 @@ namespace detail {
 /// inside the Attribute.
 template <
     typename AttrClass,
-    // Require AttrClass to be a derived class from Atribute and get its
+    // Require AttrClass to be a derived class from Attribute and get its
     // value type
     typename ValueType =
         typename std::enable_if<std::is_base_of<Attribute, AttrClass>::value,

--- a/include/mlir/IR/Module.h
+++ b/include/mlir/IR/Module.h
@@ -124,7 +124,7 @@ public:
 
 /// A class used to manage the symbols held by a module. This class handles
 /// ensures that symbols inserted into a module have a unique name, and provides
-/// efficent named lookup to held symbols.
+/// efficient named lookup to held symbols.
 class ModuleManager {
 public:
   ModuleManager(ModuleOp module) : module(module), symbolTable(module) {}

--- a/include/mlir/IR/OpBase.td
+++ b/include/mlir/IR/OpBase.td
@@ -100,7 +100,7 @@ class CPred<code pred> : Pred {
   code predExpr = "(" # pred # ")";
 }
 
-// Kinds of predicate combiners.  These must closesly match the predicates
+// Kinds of predicate combiners.  These must closely match the predicates
 // implemented by the C++ backend (tblgen::PredCombinerKind).
 class PredCombinerKind;
 def PredCombinerAnd : PredCombinerKind;
@@ -622,7 +622,7 @@ class Attr<Pred condition, string descr = ""> :
   // Unset means this is a base-level Attr.
   //
   // This field is used by attribute wrapper classes (DefaultValuedAttr,
-  // OptionalAttr, etc.) to retrive the base-level attribute definition.
+  // OptionalAttr, etc.) to retrieve the base-level attribute definition.
   // This can be used for getting its name; otherwise, we will see
   // "anonymous_<number>" as the attribute def name because of template
   // instantiation.
@@ -1394,7 +1394,7 @@ class Op<Dialect dialect, string mnemonic, list<OpTrait> props = []> {
   // Additional, longer human-readable description of what the op does.
   string description = "";
 
-  // Dag containting the arguments of the op. Default to 0 arguments.
+  // Dag containing the arguments of the op. Default to 0 arguments.
   dag arguments = (ins);
 
   // The list of results of the op. Default to 0 results.
@@ -1664,7 +1664,7 @@ def addBenefit;
 //
 // Then `TwoResultOp` will replace the first two values of `ThreeResultOp`.
 //
-// You can also use `$<name>__N` to explicitly access the N-th reusult.
+// You can also use `$<name>__N` to explicitly access the N-th result.
 // ```
 // def : Pattern<(FiveResultOp ...),
 //               [(TwoResultOp1:$res1__1 ...), (replaceWithValue $res1__0),

--- a/include/mlir/IR/OperationSupport.h
+++ b/include/mlir/IR/OperationSupport.h
@@ -306,7 +306,7 @@ public:
 
   void addSuccessor(Block *successor, ArrayRef<Value *> succOperands) {
     successors.push_back(successor);
-    // Insert a sentinal operand to mark a barrier between successor operands.
+    // Insert a sentinel operand to mark a barrier between successor operands.
     operands.push_back(nullptr);
     operands.append(succOperands.begin(), succOperands.end());
   }

--- a/include/mlir/IR/Types.h
+++ b/include/mlir/IR/Types.h
@@ -48,7 +48,7 @@ struct OpaqueTypeStorage;
 /// Types are constructed and uniqued via the 'detail::TypeUniquer' class.
 ///
 /// Derived type classes are expected to implement several required
-/// implementaiton hooks:
+/// implementation hooks:
 ///  * Required:
 ///    - static bool kindof(unsigned kind);
 ///      * Returns if the provided type kind corresponds to an instance of the

--- a/include/mlir/Pass/PassInstrumentation.h
+++ b/include/mlir/Pass/PassInstrumentation.h
@@ -33,7 +33,7 @@ namespace detail {
 struct PassInstrumentorImpl;
 } // end namespace detail
 
-/// PassInstrumentation provdes several entry points into the pass manager
+/// PassInstrumentation provides several entry points into the pass manager
 /// infrastructure. Instrumentations should be added directly to a PassManager
 /// before running a pipeline.
 class PassInstrumentation {

--- a/include/mlir/Quantizer/Support/Metadata.h
+++ b/include/mlir/Quantizer/Support/Metadata.h
@@ -86,7 +86,7 @@ struct CAGUniformMetadata {
   /// expressed which must be satisfied.
   static constexpr int SalienceRequired = 200;
 
-  /// The range that the scheme must represent in order to accomadate the
+  /// The range that the scheme must represent in order to accommodate the
   /// underlying data.
   ExpandingMinMaxFact requiredRange;
 

--- a/include/mlir/Quantizer/Support/Statistics.h
+++ b/include/mlir/Quantizer/Support/Statistics.h
@@ -57,7 +57,7 @@ public:
   /// then getForAxis(...) can be used.
   virtual bool supportsPerAxis() const { return false; }
 
-  /// Count of axises supported in a per-axis query.
+  /// Count of axes supported in a per-axis query.
   virtual unsigned getAxisCount() const { return 0; }
 
   /// Gets statistics for a specific axis (0..getAxisCount() - 1).
@@ -67,7 +67,7 @@ public:
   }
 };
 
-/// Wraps an MLIR Attribte and returns statistics about it.
+/// Wraps an MLIR Attribute and returns statistics about it.
 /// It is expected that the attribute be one of:
 ///   FloatAttr (scalar)
 ///   DenseFPElementsAttr

--- a/include/mlir/Quantizer/Support/UniformSolvers.h
+++ b/include/mlir/Quantizer/Support/UniformSolvers.h
@@ -42,7 +42,7 @@ struct UniformStorageParams {
   int64_t minValue;
 };
 
-/// Solves for the uniform quantization scheme paramers delta and z given
+/// Solves for the uniform quantization scheme parameters delta and z given
 /// bounding min/max.
 class UniformParamsFromMinMaxSolver {
 public:

--- a/include/mlir/TableGen/Operator.h
+++ b/include/mlir/TableGen/Operator.h
@@ -45,7 +45,7 @@ namespace mlir {
 namespace tblgen {
 
 // Wrapper class that contains a MLIR op's information (e.g., operands,
-// atributes) defined in TableGen and provides helper methods for
+// attributes) defined in TableGen and provides helper methods for
 // accessing them.
 class Operator {
 public:
@@ -96,7 +96,7 @@ public:
   // Returns the number of variadic results in this operation.
   unsigned getNumVariadicResults() const;
 
-  // Op attribute interators.
+  // Op attribute iterators.
   using attribute_iterator = const NamedAttribute *;
   attribute_iterator attribute_begin() const;
   attribute_iterator attribute_end() const;

--- a/include/mlir/TableGen/Pattern.h
+++ b/include/mlir/TableGen/Pattern.h
@@ -309,7 +309,7 @@ public:
   // Returns true if the given `symbol` is bound.
   bool contains(StringRef symbol) const;
 
-  // Returns an interator to the information of the given symbol named as `key`.
+  // Returns an iterator to the information of the given symbol named as `key`.
   const_iterator find(StringRef key) const;
 
   // Returns the number of static values of the given `symbol` corresponds to.
@@ -321,14 +321,14 @@ public:
   // Returns a string containing the C++ expression for referencing this
   // symbol as a value (if this symbol represents one static value) or a value
   // range (if this symbol represents multiple static values). `fmt` is used to
-  // format each value. `separator` is used to seperate values if `symbol`
+  // format each value. `separator` is used to separate values if `symbol`
   // represents a value range.
   std::string getValueAndRangeUse(StringRef symbol, const char *fmt = "{0}",
                                   const char *separator = ", ") const;
 
   // Returns a string containing the C++ expression for referencing this
   // symbol as a value range regardless of how many static values this symbol
-  // represents. `fmt` is used to format each value. `seperator` is used to
+  // represents. `fmt` is used to format each value. `separator` is used to
   // separate values in the range.
   std::string getAllRangeUse(StringRef symbol, const char *fmt = "{0}",
                              const char *separator = ", ") const;

--- a/include/mlir/Target/LLVMIR.h
+++ b/include/mlir/Target/LLVMIR.h
@@ -24,7 +24,7 @@
 
 #include <memory>
 
-// Forward-declare LLVM classses.
+// Forward-declare LLVM classes.
 namespace llvm {
 class LLVMContext;
 class Module;

--- a/include/mlir/Target/NVVMIR.h
+++ b/include/mlir/Target/NVVMIR.h
@@ -24,7 +24,7 @@
 
 #include <memory>
 
-// Forward-declare LLVM classses.
+// Forward-declare LLVM classes.
 namespace llvm {
 class Module;
 } // namespace llvm

--- a/include/mlir/Target/ROCDLIR.h
+++ b/include/mlir/Target/ROCDLIR.h
@@ -25,7 +25,7 @@
 
 #include <memory>
 
-// Forward-declare LLVM classses.
+// Forward-declare LLVM classes.
 namespace llvm {
 class Module;
 } // namespace llvm

--- a/include/mlir/Transforms/InliningUtils.h
+++ b/include/mlir/Transforms/InliningUtils.h
@@ -182,7 +182,7 @@ public:
 /// remappings for the entry arguments to the region. 'resultsToReplace'
 /// corresponds to any results that should be replaced by terminators within the
 /// inlined region. 'inlineLoc' is an optional Location that, if provided, will
-/// be used to update the inlined operations's location information.
+/// be used to update the inlined operations' location information.
 /// 'shouldCloneInlinedRegion' corresponds to whether the source region should
 /// be cloned into the 'inlinePoint' or spliced directly.
 LogicalResult inlineRegion(InlinerInterface &interface, Region *src,

--- a/include/mlir/Transforms/Passes.h
+++ b/include/mlir/Transforms/Passes.h
@@ -37,7 +37,7 @@ template <typename T> class OpPassBase;
 /// Creates a constant folding pass. Note that this pass solely provides simple
 /// top-down constant folding functionality; it is intended to be used for
 /// testing purpose. Use Canonicalizer pass, which exploits more simplification
-/// opportunties exposed by constant folding, for the general cases.
+/// opportunities exposed by constant folding, for the general cases.
 std::unique_ptr<OpPassBase<FuncOp>> createTestConstantFoldPass();
 
 /// Creates an instance of the Canonicalizer pass.

--- a/tools/mlir-tblgen/EnumsGen.cpp
+++ b/tools/mlir-tblgen/EnumsGen.cpp
@@ -215,7 +215,7 @@ void mlir::tblgen::emitEnumDecl(const Record &enumDef,
   // Emit the enum class definition
   emitEnumClass(enumDef, enumName, underlyingType, description, enumerants, os);
 
-  // Emit coversion function declarations
+  // Emit conversion function declarations
   if (llvm::all_of(enumerants, [](EnumAttrCase enumerant) {
         return enumerant.getValue() >= 0;
       })) {

--- a/tools/mlir-tblgen/LLVMIRConversionGen.cpp
+++ b/tools/mlir-tblgen/LLVMIRConversionGen.cpp
@@ -53,7 +53,7 @@ struct StringLoc {
 } // namespace
 
 // Find the next TableGen variable in the given pattern.  These variables start
-// with a `$` character and can contain alphannumeric characters or underscores.
+// with a `$` character and can contain alphanumeric characters or underscores.
 // Return the position of the variable in the pattern and its length, including
 // the `$` character.  The escape syntax `$$` is also detected and returned.
 static StringLoc findNextVariable(StringRef str) {

--- a/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -903,7 +903,7 @@ void OpEmitter::genBuilder() {
   // 3. one having an aggregated parameter for all result types / operands /
   //    attributes, and
   genCollectiveParamBuilder();
-  // 4. one having a stand-alone prameter for each operand and attribute,
+  // 4. one having a stand-alone parameter for each operand and attribute,
   //    use the first operand or attribute's type as all result types
   // to facilitate different call patterns.
   if (op.getNumVariadicResults() == 0) {

--- a/tools/mlir-tblgen/SPIRVUtilsGen.cpp
+++ b/tools/mlir-tblgen/SPIRVUtilsGen.cpp
@@ -110,7 +110,7 @@ static void emitAttributeSerialization(const Attribute &attr,
 }
 
 /// Generates code to serialize the operands of a SPV_Op `op` into `os`. The
-/// generated querries the SSA-ID if operand is a SSA-Value, or serializes the
+/// generated queries the SSA-ID if operand is a SSA-Value, or serializes the
 /// attributes. The `operands` vector is updated appropriately. `elidedAttrs`
 /// updated as well to include the serialized attributes.
 static void emitOperandSerialization(const Operator &op, ArrayRef<SMLoc> loc,
@@ -606,7 +606,7 @@ static bool emitSerializationFns(const RecordKeeper &recordKeeper,
       serFn(serFnString), deserFn(deserFnString), utils(utilsString);
   auto attrClass = recordKeeper.getClass("Attr");
 
-  // Emit the serialization and deserialization functions simulataneously.
+  // Emit the serialization and deserialization functions simultaneously.
   declareOpcodeFn(utils);
   StringRef opVar("op");
   StringRef opcode("opcode"), words("words");


### PR DESCRIPTION
This PR addresses spelling tweaks under include and tools directories.   
This PR belongs to the same group as #175.