### PR TITLE
[spirv] Add a canonicalization pattern for spv.selection.

### DIFF
--- a/include/mlir/Dialect/SPIRV/SPIRVControlFlowOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVControlFlowOps.td
@@ -379,6 +379,8 @@ def SPV_SelectionOp : SPV_Op<"selection"> {
   let hasOpcode = 0;
 
   let autogenSerialization = 0;
+
+  let hasCanonicalizer = 1;
 }
 
 #endif // SPIRV_CONTROLFLOW_OPS

--- a/include/mlir/Dialect/SPIRV/SPIRVOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVOps.td
@@ -485,6 +485,15 @@ def SPV_StoreOp : SPV_Op<"Store", []> {
     OptionalAttr<I32Attr>:$alignment
   );
 
+  let builders = [
+    OpBuilder<"Builder *builder, OperationState &state, "
+      "Value *ptr, Value *value, ArrayRef<NamedAttribute> namedAttrs", [{
+      state.addOperands(ptr);
+      state.addOperands(value);
+      state.addAttributes(namedAttrs);
+    }]>
+  ];
+
   let results = (outs);
 }
 

--- a/lib/Dialect/SPIRV/SPIRVOps.cpp
+++ b/lib/Dialect/SPIRV/SPIRVOps.cpp
@@ -26,6 +26,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Function.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/Support/Functional.h"
 #include "mlir/Support/StringExtras.h"
@@ -1938,6 +1939,169 @@ void spirv::SelectionOp::addMergeBlock() {
 
   // Add a spv._merge op into the merge block.
   builder.create<spirv::MergeOp>(getLoc());
+}
+
+namespace {
+// Blocks from the given `spv.selection` operation must satisfy the following
+// layout:
+//
+//       +-----------------------------------------------+
+//       | header block                                  |
+//       | spv.BranchConditionalOp %cond, ^case0, ^case1 |
+//       +-----------------------------------------------+
+//                            /   \
+//                             ...
+//
+//
+//   +------------------------+    +------------------------+
+//   | case #0                |    | case #1                |
+//   | spv.Store %ptr %value0 |    | spv.Store %ptr %value1 |
+//   | spv.Branch ^merge      |    | spv.Branch ^merge      |
+//   +------------------------+    +------------------------+
+//
+//
+//                             ...
+//                            \   /
+//                              v
+//                       +-------------+
+//                       | merge block |
+//                       +-------------+
+//
+struct SelectionOpCanonicalizer : public OpRewritePattern<spirv::SelectionOp> {
+  using OpRewritePattern<spirv::SelectionOp>::OpRewritePattern;
+
+  PatternMatchResult matchAndRewrite(spirv::SelectionOp selectionOp,
+                                     PatternRewriter &rewriter) const override {
+    auto *op = selectionOp.getOperation();
+    auto &body = op->getRegion(0);
+    // Verifier allows an empty region for `spv.selection`.
+    if (body.empty()) {
+      return matchFailure();
+    }
+
+    // Check that region consists of 4 blocks:
+    // header block, `true` block, `false` block and merge block.
+    if (std::distance(body.begin(), body.end()) != 4) {
+      return matchFailure();
+    }
+
+    auto *headerBlock = selectionOp.getHeaderBlock();
+    if (!onlyContainsBranchConditionalOp(headerBlock)) {
+      return matchFailure();
+    }
+
+    auto brConditionalOp =
+        cast<spirv::BranchConditionalOp>(headerBlock->front());
+
+    auto *trueBlock = brConditionalOp.getSuccessor(0);
+    auto *falseBlock = brConditionalOp.getSuccessor(1);
+    auto *mergeBlock = selectionOp.getMergeBlock();
+
+    if (!canCanonicalizeSelection(trueBlock, falseBlock, mergeBlock)) {
+      return matchFailure();
+    }
+
+    auto *trueValue = getSrcValue(trueBlock);
+    auto *falseValue = getSrcValue(falseBlock);
+    auto *ptrValue = getDstPtr(trueBlock);
+    auto storeOpAttributes =
+        cast<spirv::StoreOp>(trueBlock->front()).getOperation()->getAttrs();
+
+    auto selectOp = rewriter.create<spirv::SelectOp>(
+        selectionOp.getLoc(), trueValue->getType(), brConditionalOp.condition(),
+        trueValue, falseValue);
+    rewriter.create<spirv::StoreOp>(selectOp.getLoc(), ptrValue,
+                                    selectOp.getResult(), storeOpAttributes);
+
+    // `spv.selection` is not needed anymore.
+    rewriter.replaceOp(op, llvm::None);
+    return matchSuccess();
+  }
+
+private:
+  // Checks that given blocks follow the following rules:
+  // 1. Each conditional block consists of two operations, the first operation
+  //    is a `spv.Store` and the last operation is a `spv.Branch`.
+  // 2. Each `spv.Store` uses the same pointer and the same memory attributes.
+  // 3. A control flow goes into the given merge block from the given
+  //    conditional blocks.
+  PatternMatchResult canCanonicalizeSelection(Block *trueBlock,
+                                              Block *falseBlock,
+                                              Block *mergeBlock) const;
+
+  bool onlyContainsBranchConditionalOp(Block *block) const {
+    return std::next(block->begin()) == block->end() &&
+           isa<spirv::BranchConditionalOp>(block->front());
+  }
+
+  bool isSameAttrList(spirv::StoreOp lhs, spirv::StoreOp rhs) const {
+    return lhs.getOperation()->getAttrList().getDictionary() ==
+           rhs.getOperation()->getAttrList().getDictionary();
+  }
+
+  // Checks that given type is valid for `spv.SelectOp`.
+  // According to SPIR-V spec:
+  // "Before version 1.4, Result Type must be a pointer, scalar, or vector.
+  // Starting with version 1.4, Result Type can additionally be a composite type
+  // other than a vector."
+  bool isValidType(Type type) const {
+    return spirv::SPIRVDialect::isValidScalarType(type) ||
+           type.isa<VectorType>();
+  }
+
+  // Returns a soruce value for the given block.
+  Value *getSrcValue(Block *block) const {
+    auto storeOp = cast<spirv::StoreOp>(block->front());
+    return storeOp.value();
+  }
+
+  // Returns a destination value for the given block.
+  Value *getDstPtr(Block *block) const {
+    auto storeOp = cast<spirv::StoreOp>(block->front());
+    return storeOp.ptr();
+  }
+};
+
+PatternMatchResult SelectionOpCanonicalizer::canCanonicalizeSelection(
+    Block *trueBlock, Block *falseBlock, Block *mergeBlock) const {
+  // Each block must consists of 2 operations.
+  if ((std::distance(trueBlock->begin(), trueBlock->end()) != 2) ||
+      (std::distance(falseBlock->begin(), falseBlock->end()) != 2)) {
+    return matchFailure();
+  }
+
+  auto trueBrStoreOp = dyn_cast<spirv::StoreOp>(trueBlock->front());
+  auto trueBrBranchOp =
+      dyn_cast<spirv::BranchOp>(*std::next(trueBlock->begin()));
+  auto falseBrStoreOp = dyn_cast<spirv::StoreOp>(falseBlock->front());
+  auto falseBrBranchOp =
+      dyn_cast<spirv::BranchOp>(*std::next(falseBlock->begin()));
+
+  if (!trueBrStoreOp || !trueBrBranchOp || !falseBrStoreOp ||
+      !falseBrBranchOp) {
+    return matchFailure();
+  }
+
+  // Check that each `spv.Store` uses the same pointer, memory access
+  // attributes and a valid type of the value.
+  if ((trueBrStoreOp.ptr() != falseBrStoreOp.ptr()) ||
+      !isSameAttrList(trueBrStoreOp, falseBrStoreOp) ||
+      !isValidType(trueBrStoreOp.value()->getType())) {
+    return matchFailure();
+  }
+
+  if ((trueBrBranchOp.getOperation()->getSuccessor(0) != mergeBlock) ||
+      (falseBrBranchOp.getOperation()->getSuccessor(0) != mergeBlock)) {
+    return matchFailure();
+  }
+
+  return matchSuccess();
+}
+} // namespace
+
+void spirv::SelectionOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<SelectionOpCanonicalizer>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/SPIRV/canonicalize.mlir
+++ b/test/Dialect/SPIRV/canonicalize.mlir
@@ -74,3 +74,234 @@ func @deduplicate_composite_constant() -> (!spv.array<1 x vector<2xi32>>, !spv.a
   return %0, %1 : !spv.array<1 x vector<2xi32>>, !spv.array<1 x vector<2xi32>>
 }
 
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.selection
+//===----------------------------------------------------------------------===//
+
+func @canonicalize_selection_op_scalar_type(%cond: i1) -> () {
+  %0 = spv.constant 0: i32
+  // CHECK: %[[TRUE_VALUE:.*]] = spv.constant 1 : i32
+  %1 = spv.constant 1: i32
+  // CHECK: %[[FALSE_VALUE:.*]] = spv.constant 2 : i32
+  %2 = spv.constant 2: i32
+  // CHECK: %[[DST_VAR:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<i32, Function>
+  %3 = spv.Variable init(%0) : !spv.ptr<i32, Function>
+
+  // CHECK: %[[SRC_VALUE:.*]] = spv.Select {{%.*}}, %[[TRUE_VALUE]], %[[FALSE_VALUE]] : i1, i32
+  // CHECK-NEXT: spv.Store "Function" %[[DST_VAR]], %[[SRC_VALUE]] ["Aligned", 4] : i32
+  // CHECK-NEXT: spv.Return
+  spv.selection {
+    spv.BranchConditional %cond, ^then, ^else
+
+  ^else:
+    spv.Store "Function" %3, %2 ["Aligned", 4]: i32
+    spv.Branch ^merge
+
+  ^then:
+    spv.Store "Function" %3, %1 ["Aligned", 4]: i32
+    spv.Branch ^merge
+
+  ^merge:
+    spv._merge
+  }
+  spv.Return
+}
+
+// -----
+
+func @canonicalize_selection_op_vector_type(%cond: i1) -> () {
+  %0 = spv.constant dense<[0, 1, 2]> : vector<3xi32>
+  // CHECK: %[[TRUE_VALUE:.*]] = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  %1 = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  // CHECK: %[[FALSE_VALUE:.*]] = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  %2 = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  // CHECK: %[[DST_VAR:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<vector<3xi32>, Function>
+  %3 = spv.Variable init(%0) : !spv.ptr<vector<3xi32>, Function>
+
+  // CHECK: %[[SRC_VALUE:.*]] = spv.Select {{%.*}}, %[[TRUE_VALUE]], %[[FALSE_VALUE]] : i1, vector<3xi32>
+  // CHECK-NEXT: spv.Store "Function" %[[DST_VAR]], %[[SRC_VALUE]] ["Aligned", 8] : vector<3xi32>
+  // CHECK-NEXT: spv.Return
+  spv.selection {
+    spv.BranchConditional %cond, ^then, ^else
+
+  ^then:
+    spv.Store "Function" %3, %1 ["Aligned", 8]:  vector<3xi32>
+    spv.Branch ^merge
+
+  ^else:
+    spv.Store "Function" %3, %2 ["Aligned", 8] : vector<3xi32>
+    spv.Branch ^merge
+
+  ^merge:
+    spv._merge
+  }
+  spv.Return
+}
+
+// -----
+
+// Store to a different variables.
+func @cannot_canonicalize_selection_op_0(%cond: i1) -> () {
+  %0 = spv.constant dense<[0, 1, 2]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_0:.*]] = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  %1 = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_1:.*]] = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  %2 = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  // CHECK: %[[DST_VAR_0:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<vector<3xi32>, Function>
+  %3 = spv.Variable init(%0) : !spv.ptr<vector<3xi32>, Function>
+  // CHECK: %[[DST_VAR_1:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<vector<3xi32>, Function>
+  %4 = spv.Variable init(%0) : !spv.ptr<vector<3xi32>, Function>
+
+  // CHECK: spv.selection {
+  spv.selection {
+    spv.BranchConditional %cond, ^then, ^else
+
+  ^then:
+    // CHECK: spv.Store "Function" %[[DST_VAR_0]], %[[SRC_VALUE_0]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %3, %1 ["Aligned", 8]:  vector<3xi32>
+    spv.Branch ^merge
+
+  ^else:
+    // CHECK: spv.Store "Function" %[[DST_VAR_1]], %[[SRC_VALUE_1]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %4, %2 ["Aligned", 8] : vector<3xi32>
+    spv.Branch ^merge
+
+  ^merge:
+    spv._merge
+  }
+  spv.Return
+}
+
+// -----
+
+// A conditional block consists of more than 2 operations.
+func @cannot_canonicalize_selection_op_1(%cond: i1) -> () {
+  %0 = spv.constant dense<[0, 1, 2]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_0:.*]] = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  %1 = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_1:.*]] = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  %2 = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  // CHECK: %[[DST_VAR_0:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<vector<3xi32>, Function>
+  %3 = spv.Variable init(%0) : !spv.ptr<vector<3xi32>, Function>
+  // CHECK: %[[DST_VAR_1:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<vector<3xi32>, Function>
+  %4 = spv.Variable init(%0) : !spv.ptr<vector<3xi32>, Function>
+
+  // CHECK: spv.selection {
+  spv.selection {
+    spv.BranchConditional %cond, ^then, ^else
+
+  ^then:
+    // CHECK: spv.Store "Function" %[[DST_VAR_0]], %[[SRC_VALUE_0]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %3, %1 ["Aligned", 8] : vector<3xi32>
+    // CHECK: spv.Store "Function" %[[DST_VAR_1]], %[[SRC_VALUE_0]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %4, %1 ["Aligned", 8]:  vector<3xi32>
+    spv.Branch ^merge
+
+  ^else:
+    // CHECK: spv.Store "Function" %[[DST_VAR_1]], %[[SRC_VALUE_1]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %4, %2 ["Aligned", 8] : vector<3xi32>
+    spv.Branch ^merge
+
+  ^merge:
+    spv._merge
+  }
+  spv.Return
+}
+
+// -----
+
+// A control-flow goes into `^then` block from `^else` block.
+func @cannot_canonicalize_selection_op_2(%cond: i1) -> () {
+  %0 = spv.constant dense<[0, 1, 2]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_0:.*]] = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  %1 = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_1:.*]] = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  %2 = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  // CHECK: %[[DST_VAR:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<vector<3xi32>, Function>
+  %3 = spv.Variable init(%0) : !spv.ptr<vector<3xi32>, Function>
+
+  // CHECK: spv.selection {
+  spv.selection {
+    spv.BranchConditional %cond, ^then, ^else
+
+  ^then:
+    // CHECK: spv.Store "Function" %[[DST_VAR]], %[[SRC_VALUE_0]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %3, %1 ["Aligned", 8]:  vector<3xi32>
+    spv.Branch ^merge
+
+  ^else:
+    // CHECK: spv.Store "Function" %[[DST_VAR]], %[[SRC_VALUE_1]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %3, %2 ["Aligned", 8] : vector<3xi32>
+    spv.Branch ^then
+
+  ^merge:
+    spv._merge
+  }
+  spv.Return
+}
+
+// -----
+
+// `spv.Return` as a block terminator.
+func @cannot_canonicalize_selection_op_3(%cond: i1) -> () {
+  %0 = spv.constant dense<[0, 1, 2]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_0:.*]] = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  %1 = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_1:.*]] = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  %2 = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  // CHECK: %[[DST_VAR:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<vector<3xi32>, Function>
+  %3 = spv.Variable init(%0) : !spv.ptr<vector<3xi32>, Function>
+
+  // CHECK: spv.selection {
+  spv.selection {
+    spv.BranchConditional %cond, ^then, ^else
+
+  ^then:
+    // CHECK: spv.Store "Function" %[[DST_VAR]], %[[SRC_VALUE_0]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %3, %1 ["Aligned", 8]:  vector<3xi32>
+    spv.Return
+
+  ^else:
+    // CHECK: spv.Store "Function" %[[DST_VAR]], %[[SRC_VALUE_1]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %3, %2 ["Aligned", 8] : vector<3xi32>
+    spv.Branch ^merge
+
+  ^merge:
+    spv._merge
+  }
+  spv.Return
+}
+
+// -----
+
+// Different memory access attributes.
+func @cannot_canonicalize_selection_op_4(%cond: i1) -> () {
+  %0 = spv.constant dense<[0, 1, 2]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_0:.*]] = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  %1 = spv.constant dense<[1, 2, 3]> : vector<3xi32>
+  // CHECK: %[[SRC_VALUE_1:.*]] = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  %2 = spv.constant dense<[2, 3, 4]> : vector<3xi32>
+  // CHECK: %[[DST_VAR:.*]] = spv.Variable init({{%.*}}) : !spv.ptr<vector<3xi32>, Function>
+  %3 = spv.Variable init(%0) : !spv.ptr<vector<3xi32>, Function>
+
+  // CHECK: spv.selection {
+  spv.selection {
+    spv.BranchConditional %cond, ^then, ^else
+
+  ^then:
+    // CHECK: spv.Store "Function" %[[DST_VAR]], %[[SRC_VALUE_0]] ["Aligned", 4] : vector<3xi32>
+    spv.Store "Function" %3, %1 ["Aligned", 4]:  vector<3xi32>
+    spv.Branch ^merge
+
+  ^else:
+    // CHECK: spv.Store "Function" %[[DST_VAR]], %[[SRC_VALUE_1]] ["Aligned", 8] : vector<3xi32>
+    spv.Store "Function" %3, %2 ["Aligned", 8] : vector<3xi32>
+    spv.Branch ^merge
+
+  ^merge:
+    spv._merge
+  }
+  spv.Return
+}


### PR DESCRIPTION
This patch is addressing https://github.com/tensorflow/mlir/issues/165

Add a canonicalization pattern for spv.selection operation.
Convert spv.selection operation to spv.Select based on
simple pattern.

@antiagainst @MaheshRavishankar can you please review? Thanks!