### PR TITLE
add LLVM IR dialect hooks for FP128 and X86_FP80 types

### DIFF
--- a/include/mlir/Dialect/LLVMIR/LLVMDialect.h
+++ b/include/mlir/Dialect/LLVMIR/LLVMDialect.h
@@ -95,6 +95,8 @@ public:
   static LLVMType getDoubleTy(LLVMDialect *dialect);
   static LLVMType getFloatTy(LLVMDialect *dialect);
   static LLVMType getHalfTy(LLVMDialect *dialect);
+  static LLVMType getQuadTy(LLVMDialect *dialect);
+  static LLVMType getExtendedDoubleTy(LLVMDialect *dialect);
 
   /// Utilities used to generate integer types.
   static LLVMType getIntNTy(LLVMDialect *dialect, unsigned numBits);

--- a/include/mlir/Dialect/LLVMIR/LLVMDialect.h
+++ b/include/mlir/Dialect/LLVMIR/LLVMDialect.h
@@ -95,8 +95,8 @@ public:
   static LLVMType getDoubleTy(LLVMDialect *dialect);
   static LLVMType getFloatTy(LLVMDialect *dialect);
   static LLVMType getHalfTy(LLVMDialect *dialect);
-  static LLVMType getQuadTy(LLVMDialect *dialect);
-  static LLVMType getExtendedDoubleTy(LLVMDialect *dialect);
+  static LLVMType getFP128Ty(LLVMDialect *dialect);
+  static LLVMType getX86_FP80Ty(LLVMDialect *dialect);
 
   /// Utilities used to generate integer types.
   static LLVMType getIntNTy(LLVMDialect *dialect, unsigned numBits);

--- a/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -1219,7 +1219,8 @@ LLVMDialect::LLVMDialect(MLIRContext *context)
   impl->floatTy = LLVMType::get(context, llvm::Type::getFloatTy(llvmContext));
   impl->halfTy = LLVMType::get(context, llvm::Type::getHalfTy(llvmContext));
   impl->fp128Ty = LLVMType::get(context, llvm::Type::getFP128Ty(llvmContext));
-  impl->x86_fp80Ty = LLVMType::get(context, llvm::Type::getX86_FP80Ty(llvmContext));
+  impl->x86_fp80Ty = LLVMType::get(context,
+                                   llvm::Type::getX86_FP80Ty(llvmContext));
   /// Other Types.
   impl->voidTy = LLVMType::get(context, llvm::Type::getVoidTy(llvmContext));
 }

--- a/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -1367,6 +1367,16 @@ LLVMType LLVMType::getFloatTy(LLVMDialect *dialect) {
 LLVMType LLVMType::getHalfTy(LLVMDialect *dialect) {
   return dialect->impl->halfTy;
 }
+LLVMType LLVMType::getQuadTy(LLVMDialect *dialect) {
+  return getLocked(dialect, [=] {
+    return llvm::Type::getFP128Ty(dialect->getLLVMContext());
+  });
+}
+LLVMType LLVMType::getExtendedDoubleTy(LLVMDialect *dialect) {
+  return getLocked(dialect, [=] {
+    return llvm::Type::getX86_FP80Ty(dialect->getLLVMContext());
+  });
+}
 
 /// Utilities used to generate integer types.
 LLVMType LLVMType::getIntNTy(LLVMDialect *dialect, unsigned numBits) {

--- a/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -1219,8 +1219,8 @@ LLVMDialect::LLVMDialect(MLIRContext *context)
   impl->floatTy = LLVMType::get(context, llvm::Type::getFloatTy(llvmContext));
   impl->halfTy = LLVMType::get(context, llvm::Type::getHalfTy(llvmContext));
   impl->fp128Ty = LLVMType::get(context, llvm::Type::getFP128Ty(llvmContext));
-  impl->x86_fp80Ty = LLVMType::get(context,
-                                   llvm::Type::getX86_FP80Ty(llvmContext));
+  impl->x86_fp80Ty =
+      LLVMType::get(context, llvm::Type::getX86_FP80Ty(llvmContext));
   /// Other Types.
   impl->voidTy = LLVMType::get(context, llvm::Type::getVoidTy(llvmContext));
 }

--- a/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -1182,7 +1182,7 @@ struct LLVMDialectImpl {
   /// A set of LLVMTypes that are cached on construction to avoid any lookups or
   /// locking.
   LLVMType int1Ty, int8Ty, int16Ty, int32Ty, int64Ty, int128Ty;
-  LLVMType doubleTy, floatTy, halfTy;
+  LLVMType doubleTy, floatTy, halfTy, fp128Ty, x86_fp80Ty;
   LLVMType voidTy;
 
   /// A smart mutex to lock access to the llvm context. Unlike MLIR, LLVM is not
@@ -1218,6 +1218,8 @@ LLVMDialect::LLVMDialect(MLIRContext *context)
   impl->doubleTy = LLVMType::get(context, llvm::Type::getDoubleTy(llvmContext));
   impl->floatTy = LLVMType::get(context, llvm::Type::getFloatTy(llvmContext));
   impl->halfTy = LLVMType::get(context, llvm::Type::getHalfTy(llvmContext));
+  impl->fp128Ty = LLVMType::get(context, llvm::Type::getFP128Ty(llvmContext));
+  impl->x86_fp80Ty = LLVMType::get(context, llvm::Type::getX86_FP80Ty(llvmContext));
   /// Other Types.
   impl->voidTy = LLVMType::get(context, llvm::Type::getVoidTy(llvmContext));
 }
@@ -1367,15 +1369,11 @@ LLVMType LLVMType::getFloatTy(LLVMDialect *dialect) {
 LLVMType LLVMType::getHalfTy(LLVMDialect *dialect) {
   return dialect->impl->halfTy;
 }
-LLVMType LLVMType::getQuadTy(LLVMDialect *dialect) {
-  return getLocked(dialect, [=] {
-    return llvm::Type::getFP128Ty(dialect->getLLVMContext());
-  });
+LLVMType LLVMType::getFP128Ty(LLVMDialect *dialect) {
+  return dialect->impl->fp128Ty;
 }
-LLVMType LLVMType::getExtendedDoubleTy(LLVMDialect *dialect) {
-  return getLocked(dialect, [=] {
-    return llvm::Type::getX86_FP80Ty(dialect->getLLVMContext());
-  });
+LLVMType LLVMType::getX86_FP80Ty(LLVMDialect *dialect) {
+  return dialect->impl->x86_fp80Ty;
 }
 
 /// Utilities used to generate integer types.

--- a/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/test/Dialect/LLVMIR/roundtrip.mlir
@@ -87,6 +87,13 @@ func @ops(%arg0 : !llvm.i32, %arg1 : !llvm.float) {
   %25 = llvm.inttoptr %arg0 : !llvm.i32 to !llvm<"i32*">
   %26 = llvm.ptrtoint %25 : !llvm<"i32*"> to !llvm.i32
 
+// Extended and Quad floating point
+//
+// CHECK:       %27 = llvm.fext %arg : !llvm.float to !llvm<"x86_fp80">
+// CHECK-NEXT:  %28 = llvm.fext %arg : !llvm.float to !llvm.fp128
+  %27 = llvm.fext %arg : !llvm.float to !llvm<"x86_fp80">
+  %28 = llvm.fext %arg : !llvm.float to !llvm.fp128
+
 // CHECK:  llvm.return
   llvm.return
 }


### PR DESCRIPTION
Add the quad precision FP128 and the X86 extended floating point types to the set of LLVM IR dialect floating-point type builders.