### PR TITLE
More affine expr simplifications for floordiv and mod

### DIFF
--- a/include/mlir/IR/AffineExpr.h
+++ b/include/mlir/IR/AffineExpr.h
@@ -114,8 +114,9 @@ public:
   /// floordiv, ceildiv, and mod is only allowed w.r.t constants.
   bool isPureAffine() const;
 
-  /// Returns the greatest known integral divisor of this affine expression.
-  uint64_t getLargestKnownDivisor() const;
+  /// Returns the greatest known integral divisor of this affine expression. The
+  /// result is always positive.
+  int64_t getLargestKnownDivisor() const;
 
   /// Return true if the affine expression is a multiple of 'factor'.
   bool isMultipleOf(int64_t factor) const;

--- a/test/IR/affine-map.mlir
+++ b/test/IR/affine-map.mlir
@@ -156,7 +156,7 @@
 #map48 = (i, j, k) -> (i * 64 floordiv 64, i * 512 floordiv 128, 4 * j mod 4, 4*j*4 mod 8)
 
 // Simplifications for mod using known GCD's of the LHS expr.
-// CHECK: #map{{[0-9]+}} = (d0, d1)[s0] -> (0, 0, 0, (d0 * 4 + 3) mod 2)
+// CHECK: #map{{[0-9]+}} = (d0, d1)[s0] -> (0, 0, 0, 1)
 #map49 = (i, j)[s0] -> ( (i * 4 + 8) mod 4, 32 * j * s0 * 8 mod 256, (4*i + (j * (s0 * 2))) mod 2, (4*i + 3) mod 2)
 
 // Floordiv, ceildiv divide by one.
@@ -179,6 +179,9 @@
 
 // CHECK: #map{{[0-9]+}} = () -> ()
 #map55 = () -> ()
+
+// CHECK: #map{{[0-9]+}} = (d0, d1) -> (d0, d0 * 2 + d1 * 4 + 2, 1, 2, (d0 * 4) mod 8)
+#map56 = (d0, d1) -> ((4*d0 + 2) floordiv 4, (4*d0 + 8*d1 + 5) floordiv 2, (2*d0 + 4*d1 + 3) mod 2, (3*d0 - 4) mod 3, (4*d0 + 8*d1) mod 8)
 
 // Single identity maps are removed.
 // CHECK: func @f0(memref<2x4xi8, 1>)
@@ -355,3 +358,6 @@ func @f54(memref<10xi32, #map54>)
 
 // CHECK: "foo.op"() {map = #map{{[0-9]+}}} : () -> ()
 "foo.op"() {map = #map55} : () -> ()
+
+// CHECK: func @f56(memref<1x1xi8, #map{{[0-9]+}}>)
+func @f56(memref<1x1xi8, #map56>)

--- a/test/Transforms/Vectorize/compose_maps.mlir
+++ b/test/Transforms/Vectorize/compose_maps.mlir
@@ -78,7 +78,7 @@ func @simple5c() {
 }
 
 func @simple5d() {
-  // CHECK: Composed map: (d0) -> ((d0 * 4 + 24) floordiv 3)
+  // CHECK: Composed map: (d0) -> ((d0 * 4) floordiv 3 + 8)
   "test_affine_map"() { affine_map = (d0) -> (d0 - 1) } : () -> ()
   "test_affine_map"() { affine_map = (d0) -> (d0 + 7) } : () -> ()
   "test_affine_map"() { affine_map = (d0) -> (d0 * 4) } : () -> ()

--- a/test/Transforms/unroll.mlir
+++ b/test/Transforms/unroll.mlir
@@ -21,7 +21,7 @@
 // UNROLL-BY-4-DAG: [[MAP5:#map[0-9]+]] = (d0)[s0] -> (d0 + s0 + 1)
 // UNROLL-BY-4-DAG: [[MAP6:#map[0-9]+]] = (d0, d1) -> (d0 * 16 + d1)
 // UNROLL-BY-4-DAG: [[MAP11:#map[0-9]+]] = (d0) -> (d0)
-// UNROLL-BY-4-DAG: [[MAP_TRIP_COUNT_MULTIPLE_FOUR:#map[0-9]+]] = ()[s0, s1, s2] -> (s0 + ((-s0 + s1) floordiv 4) * 4, s0 + ((-s0 + s2) floordiv 4) * 4, s0 + ((-s0 + 1024) floordiv 4) * 4)
+// UNROLL-BY-4-DAG: [[MAP_TRIP_COUNT_MULTIPLE_FOUR:#map[0-9]+]] = ()[s0, s1, s2] -> (s0 + ((-s0 + s1) floordiv 4) * 4, s0 + ((-s0 + s2) floordiv 4) * 4, s0 + ((-s0) floordiv 4) * 4 + 1024)
 
 // UNROLL-FULL-LABEL: func @loop_nest_simplest() {
 func @loop_nest_simplest() {


### PR DESCRIPTION
Add one more simplification for floordiv and mod affine expressions.
Examples:
 (2*d0 + 1) floordiv 2 is simplified to d0
 (8*d0 + 4*d1 + d2) floordiv 4 simplified to 4*d0 + d1 + d2 floordiv 4.
 etc.

 Similarly, (4*d1 + 1) mod 2 is simplified to 1,
            (2*d0 + 8*d1) mod 8 simplified to 2*d0 mod 8.

Change getLargestKnownDivisor to return int64_t to be consistent and
to avoid casting at call sites (since the result is mixed in expressions
of int64_t/index type).

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>