### PR TITLE
LICM pass zero trip count loop handling; zero trip count loop removal in

### DIFF
--- a/include/mlir/Dialect/LoopOps/LoopOps.h
+++ b/include/mlir/Dialect/LoopOps/LoopOps.h
@@ -52,6 +52,8 @@ void ensureLoopTerminator(Region &region, Builder &builder, Location loc);
 /// not an induction variable, then return nullptr.
 ForOp getForInductionVarOwner(Value *val);
 
+/// Returns the trip count of the loop if it's a constant, None otherwise.
+Optional<uint64_t> getConstantTripCount(ForOp forOp);
 } // end namespace loop
 } // end namespace mlir
 #endif // MLIR_LOOPOPS_OPS_H_

--- a/include/mlir/Transforms/LoopLikeInterface.h
+++ b/include/mlir/Transforms/LoopLikeInterface.h
@@ -22,6 +22,7 @@
 #ifndef MLIR_TRANSFORMS_LOOPLIKEINTERFACE_H_
 #define MLIR_TRANSFORMS_LOOPLIKEINTERFACE_H_
 
+#include "mlir/Analysis/LoopAnalysis.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/include/mlir/Transforms/LoopLikeInterface.td
+++ b/include/mlir/Transforms/LoopLikeInterface.td
@@ -56,6 +56,10 @@ def LoopLikeOpInterface : OpInterface<"LoopLikeOpInterface"> {
       }],
       "LogicalResult", "moveOutOfLoop", (ins "ArrayRef<Operation *>":$ops)
     >,
+    InterfaceMethod<"Get the trip count if it is a constant.",
+      "llvm::Optional<uint64_t>", "getConstantTripCount", (ins), [{
+      return getConstantTripCount(op);
+    }]>,
   ];
 }
 

--- a/lib/Transforms/AffineLoopInvariantCodeMotion.cpp
+++ b/lib/Transforms/AffineLoopInvariantCodeMotion.cpp
@@ -40,17 +40,17 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-#define DEBUG_TYPE "licm"
+#define DEBUG_TYPE "affine-licm"
 
 using namespace mlir;
 
 namespace {
 
-/// Loop invariant code motion (LICM) pass.
+/// Affine loop invariant code motion (LICM) pass.
+/// TODO: This pass should be removed once the new LICM pass can handle its
+///       uses.
 /// TODO(asabne) : The pass is missing zero-trip tests.
 /// TODO(asabne) : Check for the presence of side effects before hoisting.
-/// TODO: This code should be removed once the new LICM pass can handle its
-///       uses.
 struct LoopInvariantCodeMotion : public FunctionPass<LoopInvariantCodeMotion> {
   void runOnFunction() override;
   void runOnAffineForOp(AffineForOp forOp);
@@ -245,4 +245,4 @@ mlir::createAffineLoopInvariantCodeMotionPass() {
 
 static PassRegistration<LoopInvariantCodeMotion>
     pass("affine-loop-invariant-code-motion",
-         "Hoist loop invariant instructions outside of the loop");
+         "Hoist loop invariant operations outside of the loop");

--- a/test/Transforms/affine-loop-invariant-code-motion.mlir
+++ b/test/Transforms/affine-loop-invariant-code-motion.mlir
@@ -17,27 +17,23 @@ func @nested_loops_both_having_invariant_code() {
   // CHECK-NEXT: %cst_0 = constant 8.000000e+00 : f32
   // CHECK-NEXT: %1 = addf %cst, %cst_0 : f32
   // CHECK-NEXT: affine.for %arg0 = 0 to 10 {
-  // CHECK-NEXT: affine.store %1, %0[%arg0] : memref<10xf32>
+  // CHECK-NEXT:   affine.store %1, %0[%arg0] : memref<10xf32>
 
   return
 }
 
-// The store-load forwarding can see through affine apply's since it relies on
-// dependence information.
-// CHECK-LABEL: func @store_affine_apply
-func @store_affine_apply() -> memref<10xf32> {
+// CHECK-LABEL: func @store_affine_for
+func @store_affine_for() -> memref<10xf32> {
   %cf7 = constant 7.0 : f32
   %m = alloc() : memref<10xf32>
   affine.for %arg0 = 0 to 10 {
-      %t0 = affine.apply (d1) -> (d1 + 1)(%arg0)
-      affine.store %cf7, %m[%t0] : memref<10xf32>
+    affine.store %cf7, %m[%arg0 + 1] : memref<10xf32>
   }
   return %m : memref<10xf32>
 // CHECK:       %cst = constant 7.000000e+00 : f32
 // CHECK-NEXT:  %0 = alloc() : memref<10xf32>
 // CHECK-NEXT:  affine.for %arg0 = 0 to 10 {
-// CHECK-NEXT:      %1 = affine.apply #map3(%arg0)
-// CHECK-NEXT:      affine.store %cst, %0[%1] : memref<10xf32>
+// CHECK-NEXT:      affine.store %cst, %0[%arg0 + 1] : memref<10xf32>
 // CHECK-NEXT:  }
 // CHECK-NEXT:  return %0 : memref<10xf32>
 }

--- a/test/Transforms/loop-invariant-code-motion.mlir
+++ b/test/Transforms/loop-invariant-code-motion.mlir
@@ -199,10 +199,54 @@ func @invariant_affine_nested_if_else() {
   // CHECK-NEXT: }
   // CHECK-NEXT: }
 
+  return
+}
+
+// CHECK-LABEL: func @zero_trip_count_affine
+func @zero_trip_count_affine() {
+  %m = alloc() : memref<10xf32>
+  %cf7 = constant 7.0 : f32
+  %N = constant 0 : index
+
+  affine.for %arg0 = 0 to %N {
+    affine.for %arg1 = 0 to 10 {
+      %v0 = addf %cf7, %cf7 : f32
+    }
+  }
+  // CHECK:      alloc() : memref<10xf32>
+  // CHECK-NEXT: %cst = constant 7.000000e+00 : f32
+  // CHECK-NEXT: %c0 = constant 0 : index
+  // CHECK-NEXT: affine.for
+  // CHECK-NEXT:   addf
+  // CHECK-NEXT:   affine.for
 
   return
 }
 
+// CHECK-LABEL: func @zero_trip_count_loop
+func @zero_trip_count_loop(%N : index) {
+  %m = alloc() : memref<10xf32>
+  %cf7 = constant 7.0 : f32
+  %c1 = constant 1 : index
+  %c5 = constant 5 : index
+
+  loop.for %i = %N to %N step %c1 {
+    loop.for %j = %c5 to %c5 step %c1 {
+      addf %cf7, %cf7 : f32
+    }
+  }
+  // CHECK:      alloc() : memref<10xf32>
+  // CHECK-NEXT: %cst = constant 7.000000e+00 : f32
+  // CHECK-NEXT: %c1 = constant 1 : index
+  // CHECK-NEXT: %c5 = constant 5 : index
+  // CHECK-NEXT: loop.for
+  // CHECK-NEXT:   loop.for
+  // CHECK-NEXT:     addf
+
+  return
+}
+
+// CHECK-LABEL: func @invariant_loop_dialect
 func @invariant_loop_dialect() {
   %ci0 = constant 0 : index
   %ci10 = constant 10 : index
@@ -211,7 +255,7 @@ func @invariant_loop_dialect() {
   %cf7 = constant 7.0 : f32
   %cf8 = constant 8.0 : f32
   loop.for %arg0 = %ci0 to %ci10 step %ci1 {
-    loop.for %arg1 = %ci0 to %ci10 step %ci1 {
+    loop.for %arg1 = %ci0 to %ci1 step %ci10 {
       %v0 = addf %cf7, %cf8 : f32
     }
   }
@@ -237,8 +281,8 @@ func @variant_loop_dialect() {
 
   // CHECK: %0 = alloc() : memref<10xf32>
   // CHECK-NEXT: loop.for
-  // CHECK-NEXT: loop.for
-  // CHECK-NEXT: addi
+  // CHECK-NEXT:   loop.for
+  // CHECK-NEXT:     addi
 
   return
 }

--- a/test/Transforms/simplify-affine-structures.mlir
+++ b/test/Transforms/simplify-affine-structures.mlir
@@ -235,3 +235,22 @@ func @test_empty_set(%N : index) {
 
   return
 }
+
+// CHECK-LABEL: func @zero_trip_count_loops
+func @zero_trip_count_loops(%N : index) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c-1 = constant -1 : index
+  %M = affine.apply (d0) -> ((2*d0 + 4) mod 2)(%N)
+  affine.for %i = 0 to %M {
+  }
+  affine.for %i = 0 to -1 {
+  }
+  loop.for %i = %M to %M step %c1 {
+  }
+  loop.for %i = %c0 to %c-1 step %N {
+  }
+  // All loops above should disappear.
+  // CHECK-NOT: loop.for
+  return
+}

--- a/tools/mlir-tblgen/OpInterfacesGen.cpp
+++ b/tools/mlir-tblgen/OpInterfacesGen.cpp
@@ -41,7 +41,10 @@ using mlir::tblgen::OpInterfaceMethod;
 // beginning of the argument list.
 static void emitMethodNameAndArgs(const OpInterfaceMethod &method,
                                   raw_ostream &os, bool addOperationArg) {
-  os << method.getName() << '(';
+  // Whenever an operation argument is added, suffix helper method name with an
+  // underscore to avoid conflicts with free functions of same name on the
+  // concrete ops using this interface.
+  os << method.getName() << (addOperationArg ? "_(" : "(");
   if (addOperationArg)
     os << "Operation *tablegen_opaque_op" << (method.arg_empty() ? "" : ", ");
   interleaveComma(method.getArguments(), os,
@@ -64,9 +67,11 @@ static void emitInterfaceDef(OpInterface &interface, raw_ostream &os) {
     emitMethodNameAndArgs(method, os, /*addOperationArg=*/false);
 
     // Forward to the method on the concrete operation type.
-    os << " {\n      return getImpl()->" << method.getName() << '(';
+    os << " {\n      return getImpl()->" << method.getName();
     if (!method.isStatic())
-      os << "getOperation()" << (method.arg_empty() ? "" : ", ");
+      os << "_(getOperation()" << (method.arg_empty() ? "" : ", ");
+    else
+      os << "(";
     interleaveComma(
         method.getArguments(), os,
         [&](const OpInterfaceMethod::Argument &arg) { os << arg.name; });


### PR DESCRIPTION
-simplify-affine-structures

- addresses #194

- change name of tablegen auto-generated internal helper for op
  interfaces to avoid potential conflicts with methods of same
  name in dialect namespaces. (addresses #197)

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>