### PR TITLE
Bugfix: Keep worklistMap in sync with worklist in GreedyPatternRewriter

### DIFF
--- a/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+++ b/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
@@ -79,6 +79,7 @@ public:
     if (it != worklistMap.end()) {
       assert(worklist[it->second] == op && "malformed worklist data structure");
       worklist[it->second] = nullptr;
+      worklistMap.erase(it);
     }
   }
 


### PR DESCRIPTION
When we removed a pattern, we removed it from worklist but not from
worklistMap. Then, when we tried to add a new pattern on the same Operation
again, the pattern wasn't added since it already existed in the
worklistMap (but not in the worklist).