### PR TITLE
Allow dialect to create friendly names for block arguments

### DIFF
--- a/include/mlir/IR/OpImplementation.h
+++ b/include/mlir/IR/OpImplementation.h
@@ -594,6 +594,9 @@ public:
   /// Get a special name to use when printing the given operation. The desired
   /// name should be streamed into 'os'.
   virtual void getOpResultName(Operation *op, raw_ostream &os) const {}
+  /// Get a special name to use when printing the block arguments. The desired
+  /// name should be streamed into 'os'.
+  virtual void getBlockArgumentName(BlockArgument *arg, raw_ostream &os) const {}
 };
 
 } // end namespace mlir

--- a/include/mlir/IR/OpImplementation.h
+++ b/include/mlir/IR/OpImplementation.h
@@ -594,9 +594,10 @@ public:
   /// Get a special name to use when printing the given operation. The desired
   /// name should be streamed into 'os'.
   virtual void getOpResultName(Operation *op, raw_ostream &os) const {}
-  /// Get a special name to use when printing the block arguments. The desired
-  /// name should be streamed into 'os'.
-  virtual void getBlockArgumentName(BlockArgument *arg, raw_ostream &os) const {}
+  /// Get a special name to use when printing the entry block arguments for any
+  /// region contained by an Op in this dialect.  The desired name should be
+  /// streamed into 'os'.  If the result is empty, the default name will be used.
+  virtual void getRegionArgumentName(BlockArgument *arg, raw_ostream &os) const {}
 };
 
 } // end namespace mlir

--- a/lib/IR/AsmPrinter.cpp
+++ b/lib/IR/AsmPrinter.cpp
@@ -1523,12 +1523,15 @@ void OperationPrinter::numberValueID(Value *value) {
       // If the value is the result of an Op, ask the Op's dialect for a name
       if (auto *interface = state->getOpAsmInterface(op->getDialect()))
         interface->getOpResultName(op, specialName);
-    } else if (auto* arg = mlir::dyn_cast<mlir::BlockArgument>(value)) {
-      // Otherwise, if the value is a block argument, find it's parent op and
-      // ask it's dialect for a friendly name
-      if (auto* op = arg->getOwner()->getParentOp()) {
-        if (auto *interface = state->getOpAsmInterface(op->getDialect()))
-          interface->getBlockArgumentName(arg, specialName);
+    } else {
+      // Otherwise, if the value is an entry block argument, find it's parent
+      // and ask it's dialect for a friendly name
+      auto arg = cast<BlockArgument>(value);
+      if (arg->getOwner()->isEntryBlock()) {
+        if (auto* op = arg->getOwner()->getParentOp()) {
+          if (auto *interface = state->getOpAsmInterface(op->getDialect()))
+            interface->getRegionArgumentName(arg, specialName);
+        }
       }
     }
   }


### PR DESCRIPTION
Provide a callback similar to getOpResultName but for block arguments.