### PR TITLE
add LLVM IR to build the fneg instruction

### DIFF
--- a/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -132,6 +132,15 @@ class LLVM_ArithmeticOp<string mnemonic, string builderFunc,
   let parser = [{ return impl::parseOneResultSameOperandTypeOp(parser, result); }];
   let printer = [{ mlir::impl::printOneResultOp(this->getOperation(), p); }];
 }
+class LLVM_UnaryArithmeticOp<string mnemonic, string builderFunc,
+                        list<OpTrait> traits = []> :
+    LLVM_OneResultOp<mnemonic,
+           !listconcat([NoSideEffect, SameOperandsAndResultType], traits)>,
+    Arguments<(ins LLVM_Type:$operand)>,
+    LLVM_Builder<"$res = builder." # builderFunc # "($operand);"> {
+  let parser = [{ return impl::parseOneResultSameOperandTypeOp(parser, result); }];
+  let printer = [{ mlir::impl::printOneResultOp(this->getOperation(), p); }];
+}
 
 // Integer binary operations.
 def LLVM_AddOp : LLVM_ArithmeticOp<"add", "CreateAdd", [Commutative]>;
@@ -247,6 +256,7 @@ def LLVM_FSubOp : LLVM_ArithmeticOp<"fsub", "CreateFSub">;
 def LLVM_FMulOp : LLVM_ArithmeticOp<"fmul", "CreateFMul">;
 def LLVM_FDivOp : LLVM_ArithmeticOp<"fdiv", "CreateFDiv">;
 def LLVM_FRemOp : LLVM_ArithmeticOp<"frem", "CreateFRem">;
+def LLVM_FNegOp : LLVM_UnaryArithmeticOp<"fneg", "CreateFNeg">;
 
 // Memory-related operations.
 def LLVM_AllocaOp :

--- a/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/test/Dialect/LLVMIR/roundtrip.mlir
@@ -94,6 +94,9 @@ func @ops(%arg0 : !llvm.i32, %arg1 : !llvm.float) {
   %27 = llvm.fpext %arg1 : !llvm.float to !llvm.x86_fp80
   %28 = llvm.fpext %arg1 : !llvm.float to !llvm.fp128
 
+// CHECK:  %29 = llvm.fneg %arg1 : !llvm.float
+  %29 = llvm.fneg %arg1 : !llvm.float
+
 // CHECK:  llvm.return
   llvm.return
 }

--- a/test/Target/llvmir.mlir
+++ b/test/Target/llvmir.mlir
@@ -803,6 +803,9 @@ llvm.func @ops(%arg0: !llvm.float, %arg1: !llvm.float, %arg2: !llvm.i32, %arg3: 
 // CHECK-NEXT: %22 = ashr i32 %2, %3
   %18 = llvm.ashr %arg2, %arg3 : !llvm.i32
 
+// CHECK-NEXT: fneg float %0
+  %19 = llvm.fneg %arg0 : !llvm.float
+
   llvm.return %10 : !llvm<"{ float, i32 }">
 }
 


### PR DESCRIPTION
Adding the fneg instruction to the LLVM IR dialect.  We want to target this LLVM instruction from FIR.