### PR TITLE
fix link-time duplicate symbol error

### DIFF
--- a/include/mlir/Pass/AnalysisManager.h
+++ b/include/mlir/Pass/AnalysisManager.h
@@ -70,7 +70,7 @@ public:
 
 private:
   /// An identifier used to represent all potential analyses.
-  constexpr static AnalysisID allAnalysesID = {};
+  const static AnalysisID allAnalysesID;
 
   /// The set of analyses that are known to be preserved.
   SmallPtrSet<const void *, 2> preservedIDs;

--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -725,4 +725,4 @@ void PassInstrumentor::addInstrumentation(
   impl->instrumentations.emplace_back(std::move(pi));
 }
 
-constexpr AnalysisID mlir::detail::PreservedAnalyses::allAnalysesID;
+const AnalysisID mlir::detail::PreservedAnalyses::allAnalysesID;


### PR DESCRIPTION
We ran into a duplicate symbols link-time error when calling markAllAnalysesPreserved() in our pass.

This change eliminates the linker error.
