### PR TITLE
typos

### DIFF
--- a/g3doc/Dialects/Standard.md
+++ b/g3doc/Dialects/Standard.md
@@ -604,11 +604,11 @@ performed. The following comparisons are supported:
 -   equal (mnemonic: `"eq"`; integer value: `0`)
 -   not equal (mnemonic: `"ne"`; integer value: `1`)
 -   signed less than (mnemonic: `"slt"`; integer value: `2`)
--   signed less than or equal (mnemonic: `"slt"`; integer value: `3`)
+-   signed less than or equal (mnemonic: `"sle"`; integer value: `3`)
 -   signed greater than (mnemonic: `"sgt"`; integer value: `4`)
 -   signed greater than or equal (mnemonic: `"sge"`; integer value: `5`)
 -   unsigned less than (mnemonic: `"ult"`; integer value: `6`)
--   unsigned less than or equal (mnemonic: `"ult"`; integer value: `7`)
+-   unsigned less than or equal (mnemonic: `"ule"`; integer value: `7`)
 -   unsigned greater than (mnemonic: `"ugt"`; integer value: `8`)
 -   unsigned greater than or equal (mnemonic: `"uge"`; integer value: `9`)
 


### PR DESCRIPTION
The mnemonic "sgt" and "ult" are used twice! The second "slt" should be "sge" for "signed greater than or equal" and the second "ult" should be "ule"  for "unsigned less than or equal".