### PR TITLE
[spirv] Add bit ops

### DIFF
--- a/include/mlir/Dialect/SPIRV/SPIRVBase.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVBase.td
@@ -173,6 +173,9 @@ def SPV_OC_OpBitwiseOr              : I32EnumAttrCase<"OpBitwiseOr", 197>;
 def SPV_OC_OpBitwiseXor             : I32EnumAttrCase<"OpBitwiseXor", 198>;
 def SPV_OC_OpBitwiseAnd             : I32EnumAttrCase<"OpBitwiseAnd", 199>;
 def SPV_OC_OpNot                    : I32EnumAttrCase<"OpNot", 200>;
+def SPV_OC_OpBitFieldInsert         : I32EnumAttrCase<"OpBitFieldInsert", 201>;
+def SPV_OC_OpBitFieldSExtract       : I32EnumAttrCase<"OpBitFieldSExtract", 202>;
+def SPV_OC_OpBitFieldUExtract       : I32EnumAttrCase<"OpBitFieldUExtract", 203>;
 def SPV_OC_OpBitReverse             : I32EnumAttrCase<"OpBitReverse", 204>;
 def SPV_OC_OpBitCount               : I32EnumAttrCase<"OpBitCount", 205>;
 def SPV_OC_OpControlBarrier         : I32EnumAttrCase<"OpControlBarrier", 224>;
@@ -221,11 +224,12 @@ def SPV_OpcodeAttr :
       SPV_OC_OpFOrdGreaterThanEqual, SPV_OC_OpFUnordGreaterThanEqual,
       SPV_OC_OpShiftRightLogical, SPV_OC_OpShiftRightArithmetic,
       SPV_OC_OpShiftLeftLogical, SPV_OC_OpBitwiseOr, SPV_OC_OpBitwiseXor,
-      SPV_OC_OpBitwiseAnd, SPV_OC_OpNot, SPV_OC_OpBitReverse, SPV_OC_OpBitCount,
-      SPV_OC_OpControlBarrier, SPV_OC_OpMemoryBarrier, SPV_OC_OpPhi,
-      SPV_OC_OpLoopMerge, SPV_OC_OpSelectionMerge, SPV_OC_OpLabel, SPV_OC_OpBranch,
-      SPV_OC_OpBranchConditional, SPV_OC_OpReturn, SPV_OC_OpReturnValue,
-      SPV_OC_OpUnreachable, SPV_OC_OpModuleProcessed
+      SPV_OC_OpBitwiseAnd, SPV_OC_OpNot, SPV_OC_OpBitFieldInsert,
+      SPV_OC_OpBitFieldSExtract, SPV_OC_OpBitFieldUExtract, SPV_OC_OpBitReverse,
+      SPV_OC_OpBitCount, SPV_OC_OpControlBarrier, SPV_OC_OpMemoryBarrier,
+      SPV_OC_OpPhi, SPV_OC_OpLoopMerge, SPV_OC_OpSelectionMerge, SPV_OC_OpLabel,
+      SPV_OC_OpBranch, SPV_OC_OpBranchConditional, SPV_OC_OpReturn,
+      SPV_OC_OpReturnValue, SPV_OC_OpUnreachable, SPV_OC_OpModuleProcessed
       ]> {
     let returnType = "::mlir::spirv::Opcode";
     let convertFromStorage = "static_cast<::mlir::spirv::Opcode>($_self.getInt())";

--- a/include/mlir/Dialect/SPIRV/SPIRVBitOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVBitOps.td
@@ -33,6 +33,23 @@ class SPV_BitBinaryOp<string mnemonic, list<OpTrait> traits = []> :
                    !listconcat(traits,
                                [NoSideEffect, SameOperandsAndResultType])>;
 
+class SPV_BitFieldExtractOp<string mnemonic, list<OpTrait> traits = []> :
+      SPV_Op<mnemonic, !listconcat(traits, [NoSideEffect])> {
+  let arguments = (ins
+    SPV_ScalarOrVectorOf<SPV_Integer>:$base,
+    SPV_Integer:$offset,
+    SPV_Integer:$count
+  );
+
+  let results = (outs
+    SPV_ScalarOrVectorOf<SPV_Integer>:$result
+  );
+
+  let parser = [{ return ::parseBitFieldExtractOp(parser, result); }];
+  let printer = [{ ::printBitFieldExtractOp(this->getOperation(), p); }];
+  let verifier = [{ return ::verifyBitFieldExtractOp(this->getOperation()); }];
+}
+
 class SPV_BitUnaryOp<string mnemonic, list<OpTrait> traits = []> :
       SPV_UnaryOp<mnemonic, SPV_Integer, SPV_Integer,
                    !listconcat(traits,
@@ -80,6 +97,143 @@ def SPV_BitCountOp : SPV_BitUnaryOp<"BitCount", []> {
     ```
     %2 = spv.BitCount %0: i32
     %3 = spv.BitCount %1: vector<4xi32>
+    ```
+  }];
+}
+
+// -----
+
+def SPV_BitFieldInsertOp : SPV_Op<"BitFieldInsert", [NoSideEffect]> {
+  let summary = [{
+    Make a copy of an object, with a modified bit field that comes from
+    another object.
+  }];
+
+  let description = [{
+     Results are computed per component.
+
+    Result Type must be a scalar or vector of integer type.
+
+     The type of Base and Insert must be the same as Result Type.
+
+    Any result bits numbered outside [Offset, Offset + Count -  1]
+    (inclusive) will come from the corresponding bits in Base.
+
+    Any result bits numbered in [Offset, Offset + Count -  1] come, in
+    order, from the bits numbered [0, Count - 1] of Insert.
+
+    Count  must be an integer type scalar. Count is the number of bits taken
+    from Insert. It will be consumed as an unsigned value. Count can be 0,
+    in which case the result will be Base.
+
+    Offset  must be an integer type scalar. Offset is the lowest-order bit
+    of the bit field.  It will be consumed as an unsigned value.
+
+    The resulting value is undefined if Count or Offset or their sum is
+    greater than the number of bits in the result.
+
+    ### Custom assembly form
+
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                  `vector<` integer-literal `x` integer-type `>`
+    bitfield-insert-op ::= ssa-id `=` `spv.BitFieldInsert` ssa-use `,` ssa-use
+                                      `,` ssa-use `,` ssa-use
+                                      `:` integer-scalar-vector-type
+                                      `,` integer-type `,` integer-type
+    ```
+
+    For example:
+
+    ```
+    %0 = spv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
+    ```
+  }];
+
+  let arguments = (ins
+    SPV_ScalarOrVectorOf<SPV_Integer>:$base,
+    SPV_ScalarOrVectorOf<SPV_Integer>:$insert,
+    SPV_Integer:$offset,
+    SPV_Integer:$count
+  );
+
+  let results = (outs
+    SPV_ScalarOrVectorOf<SPV_Integer>:$result
+  );
+}
+
+// -----
+
+def SPV_BitFieldSExtractOp : SPV_BitFieldExtractOp<"BitFieldSExtract", []> {
+  let summary = "Extract a bit field from an object, with sign extension.";
+
+  let description = [{
+     Results are computed per component.
+
+    Result Type must be a scalar or vector of integer type.
+
+     The type of Base must be the same as Result Type.
+
+    If Count is greater than 0: The bits of Base numbered in [Offset, Offset
+    + Count -  1] (inclusive) become the bits numbered [0, Count - 1] of the
+    result. The remaining bits of the result will all be the same as bit
+    Offset + Count -  1 of Base.
+
+    Count  must be an integer type scalar. Count is the number of bits
+    extracted from Base. It will be consumed as an unsigned value. Count can
+    be 0, in which case the result will be 0.
+
+    Offset  must be an integer type scalar. Offset is the lowest-order bit
+    of the bit field to extract from Base.  It will be consumed as an
+    unsigned value.
+
+    The resulting value is undefined if Count or Offset or their sum is
+    greater than the number of bits in the result.
+
+    ### Custom assembly form
+
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                  `vector<` integer-literal `x` integer-type `>`
+    bitfield-exctact-s-op ::= ssa-id `=` `spv.BitFieldSExtract` ssa-use
+                                         `,` ssa-use `,` ssa-use
+                                         `:` integer-scalar-vector-type
+                                         `,` integer-type `,` integer-type
+    ```
+
+    For example:
+
+    ```
+    %0 = spv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
+    ```
+  }];
+}
+
+// -----
+
+def SPV_BitFieldUExtractOp : SPV_BitFieldExtractOp<"BitFieldUExtract", []> {
+  let summary = "Extract a bit field from an object, without sign extension.";
+
+  let description = [{
+    The semantics are the same as with OpBitFieldSExtract with the exception
+    that there is no sign extension. The remaining bits of the result will
+    all be 0.
+
+    ### Custom assembly form
+
+    ``` {.ebnf}
+    integer-scalar-vector-type ::= integer-type |
+                                  `vector<` integer-literal `x` integer-type `>`
+    bitfield-exctact-u-op ::= ssa-id `=` `spv.BitFieldUExtract` ssa-use
+                                         `,` ssa-use `,` ssa-use
+                                         `:` integer-scalar-vector-type
+                                         `,` integer-type `,` integer-type
+    ```
+
+    For example:
+
+    ```
+    %0 = spv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
   }];
 }

--- a/lib/Dialect/SPIRV/SPIRVOps.cpp
+++ b/lib/Dialect/SPIRV/SPIRVOps.cpp
@@ -381,6 +381,44 @@ static inline bool isMergeBlock(Block &block) {
 // Common parsers and printers
 //===----------------------------------------------------------------------===//
 
+static ParseResult parseBitFieldExtractOp(OpAsmParser &parser,
+                                          OperationState &state) {
+  SmallVector<OpAsmParser::OperandType, 3> operandInfo;
+  Type baseType;
+  Type offsetType;
+  Type countType;
+  auto loc = parser.getCurrentLocation();
+
+  if (parser.parseOperandList(operandInfo, 3) || parser.parseColon() ||
+      parser.parseType(baseType) || parser.parseComma() ||
+      parser.parseType(offsetType) || parser.parseComma() ||
+      parser.parseType(countType) ||
+      parser.resolveOperands(operandInfo, {baseType, offsetType, countType},
+                             loc, state.operands)) {
+    return failure();
+  }
+  state.addTypes(baseType);
+  return success();
+}
+
+static void printBitFieldExtractOp(Operation *op, OpAsmPrinter &printer) {
+  printer << op->getName() << ' ';
+  printer.printOperands(op->getOperands());
+  printer << " : " << op->getOperand(0)->getType() << ", "
+          << op->getOperand(1)->getType() << ", "
+          << op->getOperand(2)->getType();
+}
+
+static LogicalResult verifyBitFieldExtractOp(Operation *op) {
+  if (op->getOperand(0)->getType() != op->getResult(0)->getType()) {
+    return op->emitError("expected the same type for the first operand and "
+                         "result, but provided ")
+           << op->getOperand(0)->getType() << " and "
+           << op->getResult(0)->getType();
+  }
+  return success();
+}
+
 // Parses an op that has no inputs and no outputs.
 static ParseResult parseNoIOOp(OpAsmParser &parser, OperationState &state) {
   if (parser.parseOptionalAttrDict(state.attributes))
@@ -729,6 +767,55 @@ static LogicalResult verify(spirv::BitcastOp bitcastOp) {
     return bitcastOp.emitOpError("mismatch in result type bitwidth ")
            << resultBitWidth << " and operand type bitwidth "
            << operandBitWidth;
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// spv.BitFieldInsert
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseBitFieldInsertOp(OpAsmParser &parser,
+                                         OperationState &state) {
+  SmallVector<OpAsmParser::OperandType, 4> operandInfo;
+  Type baseType;
+  Type offsetType;
+  Type countType;
+  auto loc = parser.getCurrentLocation();
+
+  if (parser.parseOperandList(operandInfo, 4) || parser.parseColon() ||
+      parser.parseType(baseType) || parser.parseComma() ||
+      parser.parseType(offsetType) || parser.parseComma() ||
+      parser.parseType(countType) ||
+      parser.resolveOperands(operandInfo,
+                             {baseType, baseType, offsetType, countType}, loc,
+                             state.operands)) {
+    return failure();
+  }
+  state.addTypes(baseType);
+  return success();
+}
+
+static void print(spirv::BitFieldInsertOp bitFieldInsertOp,
+                  OpAsmPrinter &printer) {
+  printer << spirv::BitFieldInsertOp::getOperationName() << ' ';
+  printer.printOperands(bitFieldInsertOp.getOperands());
+  printer << " : " << bitFieldInsertOp.base()->getType() << ", "
+          << bitFieldInsertOp.offset()->getType() << ", "
+          << bitFieldInsertOp.count()->getType();
+}
+
+static LogicalResult verify(spirv::BitFieldInsertOp bitFieldOp) {
+  auto baseType = bitFieldOp.base()->getType();
+  auto insertType = bitFieldOp.insert()->getType();
+  auto resultType = bitFieldOp.getResult()->getType();
+
+  if ((baseType != insertType) || (baseType != resultType)) {
+    return bitFieldOp.emitError(
+               "expected the same type for the base operand, "
+               "insert operand, and "
+               "result, but provided ")
+           << baseType << ", " << insertType << " and " << resultType;
   }
   return success();
 }

--- a/test/Dialect/SPIRV/Serialization/bit-ops.mlir
+++ b/test/Dialect/SPIRV/Serialization/bit-ops.mlir
@@ -6,6 +6,21 @@ spv.module "Logical" "GLSL450" {
     %0 = spv.BitCount %arg : i32
     spv.ReturnValue %0 : i32
   }
+  func @bit_field_insert(%base: vector<3xi32>, %insert: vector<3xi32>, %offset: i32, %count: i16) -> vector<3xi32> {
+    // CHECK: {{%.*}} = spv.BitFieldInsert {{%.*}}, {{%.*}}, {{%.*}}, {{%.*}} : vector<3xi32>, i32, i16
+    %0 = spv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i32, i16
+    spv.ReturnValue %0 : vector<3xi32>
+  }
+  func @bit_field_s_extract(%base: vector<3xi32>, %offset: i8, %count: i8) -> vector<3xi32> {
+    // CHECK: {{%.*}} = spv.BitFieldSExtract {{%.*}}, {{%.*}}, {{%.*}} : vector<3xi32>, i8, i8
+    %0 = spv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
+    spv.ReturnValue %0 : vector<3xi32>
+  }
+  func @bit_field_u_extract(%base: vector<3xi32>, %offset: i8, %count: i8) -> vector<3xi32> {
+    // CHECK: {{%.*}} = spv.BitFieldUExtract {{%.*}}, {{%.*}}, {{%.*}} : vector<3xi32>, i8, i8
+    %0 = spv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
+    spv.ReturnValue %0 : vector<3xi32>
+  }
   func @bitreverse(%arg: i32) -> i32 {
     // CHECK: spv.BitReverse {{%.*}} : i32
     %0 = spv.BitReverse %arg : i32

--- a/test/Dialect/SPIRV/ops.mlir
+++ b/test/Dialect/SPIRV/ops.mlir
@@ -215,6 +215,56 @@ func @bitcount(%arg: i32) -> i32 {
 // -----
 
 //===----------------------------------------------------------------------===//
+// spv.BitFieldInsert
+//===----------------------------------------------------------------------===//
+
+func @bit_field_insert_vec(%base: vector<3xi32>, %insert: vector<3xi32>, %offset: i32, %count: i16) -> vector<3xi32> {
+  // CHECK: {{%.*}} = spv.BitFieldInsert {{%.*}}, {{%.*}}, {{%.*}}, {{%.*}} : vector<3xi32>, i32, i16
+  %0 = spv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i32, i16
+  spv.ReturnValue %0 : vector<3xi32>
+}
+
+// -----
+
+func @bit_field_insert_invalid_insert_type(%base: vector<3xi32>, %insert: vector<2xi32>, %offset: i32, %count: i16) -> vector<3xi32> {
+  // expected-error @+1 {{expected the same type for the base operand, insert operand, and result, but provided 'vector<3xi32>', 'vector<2xi32>' and 'vector<3xi32>'}}
+  %0 = "spv.BitFieldInsert" (%base, %insert, %offset, %count) : (vector<3xi32>, vector<2xi32>, i32, i16) -> vector<3xi32>
+  spv.ReturnValue %0 : vector<3xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spv.BitFieldSExtract
+//===----------------------------------------------------------------------===//
+
+func @bit_field_s_extract_vec(%base: vector<3xi32>, %offset: i8, %count: i8) -> vector<3xi32> {
+  // CHECK: {{%.*}} = spv.BitFieldSExtract {{%.*}}, {{%.*}}, {{%.*}} : vector<3xi32>, i8, i8
+  %0 = spv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
+  spv.ReturnValue %0 : vector<3xi32>
+}
+
+//===----------------------------------------------------------------------===//
+// spv.BitFieldUExtract
+//===----------------------------------------------------------------------===//
+
+func @bit_field_u_extract_vec(%base: vector<3xi32>, %offset: i8, %count: i8) -> vector<3xi32> {
+  // CHECK: {{%.*}} = spv.BitFieldUExtract {{%.*}}, {{%.*}}, {{%.*}} : vector<3xi32>, i8, i8
+  %0 = spv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
+  spv.ReturnValue %0 : vector<3xi32>
+}
+
+// -----
+
+func @bit_field_u_extract_invalid_result_type(%base: vector<3xi32>, %offset: i32, %count: i16) -> vector<4xi32> {
+  // expected-error @+1 {{expected the same type for the first operand and result, but provided 'vector<3xi32>' and 'vector<4xi32>'}}
+  %0 = "spv.BitFieldUExtract" (%base, %offset, %count) : (vector<3xi32>, i32, i16) -> vector<4xi32>
+  spv.ReturnValue %0 : vector<4xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // spv.BitReverse
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This patch addresses an issue https://github.com/tensorflow/mlir/issues/173 and adds a few bit operations:

* OpBitFieldInsert
* OpBitFieldSExtract
* OpBitFieldUExtract

@antiagainst @MaheshRavishankar can you please take a look?
Thanks!