### PR TITLE
Add OpenMP dialect to the dialect registry

### DIFF
--- a/include/mlir/IR/DialectSymbolRegistry.def
+++ b/include/mlir/IR/DialectSymbolRegistry.def
@@ -29,6 +29,7 @@ DEFINE_SYM_KIND_RANGE(QUANTIZATION)
 DEFINE_SYM_KIND_RANGE(IREE) // IREE stands for IR Execution Engine
 DEFINE_SYM_KIND_RANGE(LINALG) // Linear Algebra Dialect
 DEFINE_SYM_KIND_RANGE(FIR) // Flang Fortran IR Dialect
+DEFINE_SYM_KIND_RANGE(OPENMP) // OpenMP IR Dialect
 DEFINE_SYM_KIND_RANGE(TOY) // Toy language (tutorial) Dialect
 DEFINE_SYM_KIND_RANGE(SPIRV) // SPIR-V dialect
 


### PR DESCRIPTION
This dialect will be used by flang for OpenMP code generation