### PR TITLE
add some new parser hooks to the parser to support FIR types

### DIFF
--- a/include/mlir/IR/DialectImplementation.h
+++ b/include/mlir/IR/DialectImplementation.h
@@ -188,6 +188,12 @@ public:
   /// Parse a `}` token.
   virtual ParseResult parseRBrace() = 0;
 
+  /// Parse a '{' token if present
+  virtual ParseResult parseOptionalLBrace() = 0;
+
+  /// Parse a `}` token if present
+  virtual ParseResult parseOptionalRBrace() = 0;
+
   /// Parse a `:` token.
   virtual ParseResult parseColon() = 0;
 
@@ -263,6 +269,12 @@ public:
 
   /// Parse a `...` token if present;
   virtual ParseResult parseOptionalEllipsis() = 0;
+
+  /// Parse a `*` token.
+  virtual ParseResult parseOptionalStar() = 0;
+
+  /// Parse a `?` token.
+  virtual ParseResult parseOptionalQuestion() = 0;
 
   //===--------------------------------------------------------------------===//
   // Attribute Parsing

--- a/include/mlir/IR/DialectImplementation.h
+++ b/include/mlir/IR/DialectImplementation.h
@@ -185,11 +185,11 @@ public:
   /// Parse a '{' token.
   virtual ParseResult parseLBrace() = 0;
 
-  /// Parse a `}` token.
-  virtual ParseResult parseRBrace() = 0;
-
   /// Parse a '{' token if present
   virtual ParseResult parseOptionalLBrace() = 0;
+
+  /// Parse a `}` token.
+  virtual ParseResult parseRBrace() = 0;
 
   /// Parse a `}` token if present
   virtual ParseResult parseOptionalRBrace() = 0;
@@ -270,11 +270,11 @@ public:
   /// Parse a `...` token if present;
   virtual ParseResult parseOptionalEllipsis() = 0;
 
-  /// Parse a `*` token.
-  virtual ParseResult parseOptionalStar() = 0;
-
   /// Parse a `?` token.
   virtual ParseResult parseOptionalQuestion() = 0;
+
+  /// Parse a `*` token.
+  virtual ParseResult parseOptionalStar() = 0;
 
   //===--------------------------------------------------------------------===//
   // Attribute Parsing

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -606,14 +606,14 @@ public:
     return success(parser.consumeIf(Token::r_square));
   }
 
-  /// Parses a '*' if present.
-  ParseResult parseOptionalStar() override {
-    return success(parser.consumeIf(Token::star));
-  }
-
   /// Parses a '?' if present.
   ParseResult parseOptionalQuestion() override {
     return success(parser.consumeIf(Token::question));
+  }
+
+  /// Parses a '*' if present.
+  ParseResult parseOptionalStar() override {
+    return success(parser.consumeIf(Token::star));
   }
 
   /// Returns if the current token corresponds to a keyword.

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -501,9 +501,19 @@ public:
     return parser.parseToken(Token::l_brace, "expected '{'");
   }
 
+  /// Parse a '{' token if present
+  ParseResult parseOptionalLBrace() override {
+    return success(parser.consumeIf(Token::l_brace));
+  }
+
   /// Parse a `}` token.
   ParseResult parseRBrace() override {
     return parser.parseToken(Token::r_brace, "expected '}'");
+  }
+
+  /// Parse a `}` token if present
+  ParseResult parseOptionalRBrace() override {
+    return success(parser.consumeIf(Token::r_brace));
   }
 
   /// Parse a `:` token.
@@ -594,6 +604,16 @@ public:
   /// Parses a ']' if present.
   ParseResult parseOptionalRSquare() override {
     return success(parser.consumeIf(Token::r_square));
+  }
+
+  /// Parses a '*' if present.
+  ParseResult parseOptionalStar() override {
+    return success(parser.consumeIf(Token::star));
+  }
+
+  /// Parses a '?' if present.
+  ParseResult parseOptionalQuestion() override {
+    return success(parser.consumeIf(Token::question));
   }
 
   /// Returns if the current token corresponds to a keyword.


### PR DESCRIPTION
allow access to '?', '*', and optional '{' and '}' tokens.