### PR TITLE
SmallVector->SmallVectorImpl

### DIFF
--- a/include/mlir/Dialect/StandardOps/Ops.h
+++ b/include/mlir/Dialect/StandardOps/Ops.h
@@ -338,7 +338,7 @@ void printDimAndSymbolList(Operation::operand_iterator begin,
 
 /// Parses dimension and symbol list and returns true if parsing failed.
 ParseResult parseDimAndSymbolList(OpAsmParser &parser,
-                                  SmallVector<Value *, 4> &operands,
+                                  SmallVectorImpl<Value *> &operands,
                                   unsigned &numDims);
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, SubViewOp::Range &range);

--- a/lib/Dialect/StandardOps/Ops.cpp
+++ b/lib/Dialect/StandardOps/Ops.cpp
@@ -212,7 +212,7 @@ void mlir::printDimAndSymbolList(Operation::operand_iterator begin,
 // dimension operands parsed.
 // Returns 'false' on success and 'true' on error.
 ParseResult mlir::parseDimAndSymbolList(OpAsmParser &parser,
-                                        SmallVector<Value *, 4> &operands,
+                                        SmallVectorImpl<Value *> &operands,
                                         unsigned &numDims) {
   SmallVector<OpAsmParser::OperandType, 8> opInfos;
   if (parser.parseOperandList(opInfos, OpAsmParser::Delimiter::Paren))


### PR DESCRIPTION
LLVM ProgrammersManual indicates that `SmallVectorImpl` is preferred over `SmallVector`. Conforming to the manual may be a good idea.