### PR TITLE
Unify vector op names with other dialects.

### DIFF
--- a/include/mlir/Dialect/VectorOps/VectorOps.td
+++ b/include/mlir/Dialect/VectorOps/VectorOps.td
@@ -53,7 +53,7 @@ class Vector_Op<string mnemonic, list<OpTrait> traits = []> :
 // with operators other than the current set: {*, +}.
 // TODO(andydavis) Consider using AffineMaps to express contracting, batch
 // and free dimension pairs.
-def VectorContractionOp :
+def Vector_ContractionOp :
   Vector_Op<"contract", [NoSideEffect]>,
     Arguments<(ins AnyVector:$lhs, AnyVector:$rhs, AnyVector:$acc,
                Variadic<TupleOf<[Index]>>:$masks)>,
@@ -147,7 +147,7 @@ def VectorContractionOp :
   }];
 }
 
-def VectorExtractElementOp :
+def Vector_ExtractElementOp :
   Vector_Op<"extractelement", [NoSideEffect,
      PredOpTrait<"operand and result have same element type",
                  TCresVTEtIsSameAsOpBase<0, 0>>]>,
@@ -174,7 +174,7 @@ def VectorExtractElementOp :
   }];
 }
 
-def VectorStridedSliceOp :
+def Vector_StridedSliceOp :
   Vector_Op<"strided_slice", [NoSideEffect,
      PredOpTrait<"operand and result have same element type",
                  TCresVTEtIsSameAsOpBase<0, 0>>]>,
@@ -216,7 +216,7 @@ def VectorStridedSliceOp :
   }];
 }
 
-def VectorOuterProductOp :
+def Vector_OuterProductOp :
   Vector_Op<"outerproduct", [NoSideEffect, SameOperandsAndResultElementType]>,
     Arguments<(ins AnyVector:$lhs, AnyVector:$rhs, Variadic<AnyVector>:$acc)>,
     Results<(outs AnyVector)> {
@@ -255,7 +255,7 @@ def VectorOuterProductOp :
   }];
 }
 
-def VectorTransferReadOp :
+def Vector_TransferReadOp :
   Vector_Op<"transfer_read">,
     Arguments<(ins AnyMemRef:$memref, Variadic<Index>:$indices,
                AffineMapAttr:$permutation_map, AnyType:$padding)>,
@@ -386,7 +386,7 @@ def VectorTransferReadOp :
   }];
 }
 
-def VectorTransferWriteOp :
+def Vector_TransferWriteOp :
   Vector_Op<"transfer_write">,
     Arguments<(ins AnyVector:$vector, AnyMemRef:$memref,
                Variadic<Index>:$indices,
@@ -447,7 +447,7 @@ def VectorTransferWriteOp :
   }];
 }
 
-def VectorTypeCastOp :
+def Vector_TypeCastOp :
   Vector_Op<"type_cast", [NoSideEffect]>,
     Arguments<(ins StaticShapeMemRefOf<[AnyType]>:$memref)>,
     Results<(outs AnyMemRef)> {
@@ -490,8 +490,8 @@ def VectorTypeCastOp :
   }];
 }
 
-// TODO(andydavis) Morph this operation into a VectorMaskOp.
-def VectorIndexTupleOp :
+// TODO(andydavis) Morph this operation into a Vector_MaskOp.
+def Vector_IndexTupleOp :
   Vector_Op<"make_index_tuple", [NoSideEffect]>,
     Arguments<(ins Variadic<Index>:$operands)>,
     Results<(outs TupleOf<[Index]>)> {

--- a/include/mlir/EDSC/Intrinsics.h
+++ b/include/mlir/EDSC/Intrinsics.h
@@ -114,7 +114,10 @@ private:
   llvm::SmallVector<Value *, 8> values;
 };
 
-template <typename T> inline T unpack(T value) { return value; }
+template <typename T>
+inline T unpack(T value) {
+  return value;
+}
 
 inline detail::ValueHandleArray unpack(ArrayRef<ValueHandle> values) {
   return detail::ValueHandleArray(values);
@@ -129,7 +132,8 @@ inline detail::ValueHandleArray unpack(ArrayRef<ValueHandle> values) {
 /// Implementing it as a subclass allows it to compose all the way to Value*.
 /// Without subclassing, implicit conversion to Value* would fail when composing
 /// in patterns such as: `select(a, b, select(c, d, e))`.
-template <typename Op> struct ValueBuilder : public ValueHandle {
+template <typename Op>
+struct ValueBuilder : public ValueHandle {
   // Builder-based
   template <typename... Args>
   ValueBuilder(Args... args)
@@ -176,7 +180,8 @@ template <typename Op> struct ValueBuilder : public ValueHandle {
   ValueBuilder() : ValueHandle(ValueHandle::create<Op>()) {}
 };
 
-template <typename Op> struct OperationBuilder : public OperationHandle {
+template <typename Op>
+struct OperationBuilder : public OperationHandle {
   template <typename... Args>
   OperationBuilder(Args... args)
       : OperationHandle(OperationHandle::create<Op>(detail::unpack(args)...)) {}
@@ -215,7 +220,7 @@ using select = ValueBuilder<SelectOp>;
 using std_load = ValueBuilder<LoadOp>;
 using std_store = OperationBuilder<StoreOp>;
 using subi = ValueBuilder<SubIOp>;
-using vector_type_cast = ValueBuilder<vector::VectorTypeCastOp>;
+using vector_type_cast = ValueBuilder<vector::TypeCastOp>;
 using view = ValueBuilder<ViewOp>;
 
 /// Branches into the mlir::Block* captured by BlockHandle `b` with `operands`.

--- a/lib/Analysis/LoopAnalysis.cpp
+++ b/lib/Analysis/LoopAnalysis.cpp
@@ -274,8 +274,7 @@ static bool isVectorElement(LoadOrStoreOpPointer memoryOp) {
 }
 
 static bool isVectorTransferReadOrWrite(Operation &op) {
-  return isa<vector::VectorTransferReadOp>(op) ||
-         isa<vector::VectorTransferWriteOp>(op);
+  return isa<vector::TransferReadOp>(op) || isa<vector::TransferWriteOp>(op);
 }
 
 using VectorizableOpFun = std::function<bool(AffineForOp, Operation &)>;

--- a/lib/Analysis/VectorAnalysis.cpp
+++ b/lib/Analysis/VectorAnalysis.cpp
@@ -194,10 +194,10 @@ bool mlir::matcher::operatesOnSuperVectorsOf(Operation &op,
   bool mustDivide = false;
   (void)mustDivide;
   VectorType superVectorType;
-  if (auto read = dyn_cast<vector::VectorTransferReadOp>(op)) {
+  if (auto read = dyn_cast<vector::TransferReadOp>(op)) {
     superVectorType = read.getVectorType();
     mustDivide = true;
-  } else if (auto write = dyn_cast<vector::VectorTransferWriteOp>(op)) {
+  } else if (auto write = dyn_cast<vector::TransferWriteOp>(op)) {
     superVectorType = write.getVectorType();
     mustDivide = true;
   } else if (op.getNumResults() == 0) {

--- a/lib/Conversion/VectorConversions/VectorToLLVM.cpp
+++ b/lib/Conversion/VectorConversions/VectorToLLVM.cpp
@@ -53,15 +53,15 @@ class VectorExtractElementOpConversion : public LLVMOpLowering {
 public:
   explicit VectorExtractElementOpConversion(MLIRContext *context,
                                             LLVMTypeConverter &typeConverter)
-      : LLVMOpLowering(vector::VectorExtractElementOp::getOperationName(),
-                       context, typeConverter) {}
+      : LLVMOpLowering(vector::ExtractElementOp::getOperationName(), context,
+                       typeConverter) {}
 
   PatternMatchResult
   matchAndRewrite(Operation *op, ArrayRef<Value *> operands,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
-    auto adaptor = vector::VectorExtractElementOpOperandAdaptor(operands);
-    auto extractOp = cast<vector::VectorExtractElementOp>(op);
+    auto adaptor = vector::ExtractElementOpOperandAdaptor(operands);
+    auto extractOp = cast<vector::ExtractElementOp>(op);
     auto vectorType = extractOp.vector()->getType().cast<VectorType>();
     auto resultType = extractOp.getResult()->getType();
     auto llvmResultType = lowering.convertType(resultType);
@@ -107,21 +107,21 @@ class VectorOuterProductOpConversion : public LLVMOpLowering {
 public:
   explicit VectorOuterProductOpConversion(MLIRContext *context,
                                           LLVMTypeConverter &typeConverter)
-      : LLVMOpLowering(vector::VectorOuterProductOp::getOperationName(),
-                       context, typeConverter) {}
+      : LLVMOpLowering(vector::OuterProductOp::getOperationName(), context,
+                       typeConverter) {}
 
   PatternMatchResult
   matchAndRewrite(Operation *op, ArrayRef<Value *> operands,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
-    auto adaptor = vector::VectorOuterProductOpOperandAdaptor(operands);
+    auto adaptor = vector::OuterProductOpOperandAdaptor(operands);
     auto *ctx = op->getContext();
     auto vLHS = adaptor.lhs()->getType().cast<LLVM::LLVMType>();
     auto vRHS = adaptor.rhs()->getType().cast<LLVM::LLVMType>();
     auto rankLHS = vLHS.getUnderlyingType()->getVectorNumElements();
     auto rankRHS = vRHS.getUnderlyingType()->getVectorNumElements();
     auto llvmArrayOfVectType = lowering.convertType(
-        cast<vector::VectorOuterProductOp>(op).getResult()->getType());
+        cast<vector::OuterProductOp>(op).getResult()->getType());
     Value *desc = rewriter.create<LLVM::UndefOp>(loc, llvmArrayOfVectType);
     Value *a = adaptor.lhs(), *b = adaptor.rhs();
     Value *acc = adaptor.acc().empty() ? nullptr : adaptor.acc().front();
@@ -159,14 +159,14 @@ class VectorTypeCastOpConversion : public LLVMOpLowering {
 public:
   explicit VectorTypeCastOpConversion(MLIRContext *context,
                                       LLVMTypeConverter &typeConverter)
-      : LLVMOpLowering(vector::VectorTypeCastOp::getOperationName(), context,
+      : LLVMOpLowering(vector::TypeCastOp::getOperationName(), context,
                        typeConverter) {}
 
   PatternMatchResult
   matchAndRewrite(Operation *op, ArrayRef<Value *> operands,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
-    vector::VectorTypeCastOp castOp = cast<vector::VectorTypeCastOp>(op);
+    vector::TypeCastOp castOp = cast<vector::TypeCastOp>(op);
     MemRefType sourceMemRefType =
         castOp.getOperand()->getType().cast<MemRefType>();
     MemRefType targetMemRefType =

--- a/lib/Conversion/VectorConversions/VectorToVector.cpp
+++ b/lib/Conversion/VectorConversions/VectorToVector.cpp
@@ -355,8 +355,8 @@ struct ConvertFakeForkFromBlockArgsOp : public RewritePattern {
                           leadingSize, unrollFactors);
       extractedVectors.push_back(
           rewriter
-              .create<vector::VectorStridedSliceOp>(op->getLoc(), blockArg,
-                                                    offsets, sizes, strides)
+              .create<vector::StridedSliceOp>(op->getLoc(), blockArg, offsets,
+                                              sizes, strides)
               .getResult());
     }
     rewriter.replaceOp(op, extractedVectors);
@@ -373,7 +373,8 @@ struct FakeJoinTrait {
   static constexpr char const *name = kFakeJoinOp;
 };
 
-template <typename OpNameTrait> struct DCEPattern : public RewritePattern {
+template <typename OpNameTrait>
+struct DCEPattern : public RewritePattern {
   DCEPattern(MLIRContext *context)
       // low-benefit to kick-in late
       : RewritePattern(OpNameTrait::name, 0, context) {}

--- a/lib/Transforms/MaterializeVectors.cpp
+++ b/lib/Transforms/MaterializeVectors.cpp
@@ -146,8 +146,8 @@ using llvm::dbgs;
 using llvm::SetVector;
 
 using namespace mlir;
-using vector::VectorTransferReadOp;
-using vector::VectorTransferWriteOp;
+using vector::TransferReadOp;
+using vector::TransferWriteOp;
 
 using functional::makePtrDynCaster;
 using functional::map;
@@ -408,9 +408,9 @@ materializeAttributes(Operation *opInst, VectorType hwVectorType) {
 static Operation *instantiate(OpBuilder b, Operation *opInst,
                               VectorType hwVectorType,
                               DenseMap<Value *, Value *> *substitutionsMap) {
-  assert(!isa<VectorTransferReadOp>(opInst) &&
+  assert(!isa<TransferReadOp>(opInst) &&
          "Should call the function specialized for VectorTransferReadOp");
-  assert(!isa<VectorTransferWriteOp>(opInst) &&
+  assert(!isa<TransferWriteOp>(opInst) &&
          "Should call the function specialized for VectorTransferWriteOp");
   if (opInst->getNumRegions() != 0)
     return nullptr;
@@ -444,8 +444,8 @@ template <typename VectorTransferOpTy>
 static AffineMap projectedPermutationMap(VectorTransferOpTy transfer,
                                          VectorType hwVectorType) {
   static_assert(
-      std::is_same<VectorTransferOpTy, VectorTransferReadOp>::value ||
-          std::is_same<VectorTransferOpTy, VectorTransferWriteOp>::value,
+      std::is_same<VectorTransferOpTy, TransferReadOp>::value ||
+          std::is_same<VectorTransferOpTy, TransferWriteOp>::value,
       "Must be called on a VectorTransferOp");
   auto superVectorType = transfer.getVectorType();
   auto optionalRatio = shapeRatio(superVectorType, hwVectorType);
@@ -481,7 +481,7 @@ static AffineMap projectedPermutationMap(VectorTransferOpTy transfer,
 /// `hwVectorType` int the covering of the super-vector type. For a more
 /// detailed description of the problem, see the description of
 /// reindexAffineIndices.
-static Operation *instantiate(OpBuilder b, VectorTransferReadOp read,
+static Operation *instantiate(OpBuilder b, TransferReadOp read,
                               VectorType hwVectorType,
                               ArrayRef<int64_t> hwVectorInstance,
                               DenseMap<Value *, Value *> *substitutionsMap) {
@@ -493,7 +493,7 @@ static Operation *instantiate(OpBuilder b, VectorTransferReadOp read,
   if (!map) {
     return nullptr;
   }
-  auto cloned = b.create<VectorTransferReadOp>(
+  auto cloned = b.create<TransferReadOp>(
       read.getLoc(), hwVectorType, read.memref(), affineIndices,
       AffineMapAttr::get(map), read.padding());
   return cloned.getOperation();
@@ -505,7 +505,7 @@ static Operation *instantiate(OpBuilder b, VectorTransferReadOp read,
 /// `hwVectorType` int the covering of th3e super-vector type. For a more
 /// detailed description of the problem, see the description of
 /// reindexAffineIndices.
-static Operation *instantiate(OpBuilder b, VectorTransferWriteOp write,
+static Operation *instantiate(OpBuilder b, TransferWriteOp write,
                               VectorType hwVectorType,
                               ArrayRef<int64_t> hwVectorInstance,
                               DenseMap<Value *, Value *> *substitutionsMap) {
@@ -513,7 +513,7 @@ static Operation *instantiate(OpBuilder b, VectorTransferWriteOp write,
       map(makePtrDynCaster<Value>(), write.indices());
   auto affineIndices =
       reindexAffineIndices(b, hwVectorType, hwVectorInstance, indices);
-  auto cloned = b.create<VectorTransferWriteOp>(
+  auto cloned = b.create<TransferWriteOp>(
       write.getLoc(),
       substitute(write.vector(), hwVectorType, substitutionsMap),
       write.memref(), affineIndices,
@@ -556,12 +556,12 @@ static bool instantiateMaterialization(Operation *op,
   if (op->getNumRegions() != 0)
     return op->emitError("NYI path Op with region"), true;
 
-  if (auto write = dyn_cast<VectorTransferWriteOp>(op)) {
+  if (auto write = dyn_cast<TransferWriteOp>(op)) {
     auto *clone = instantiate(b, write, state->hwVectorType,
                               state->hwVectorInstance, state->substitutionsMap);
     return clone == nullptr;
   }
-  if (auto read = dyn_cast<VectorTransferReadOp>(op)) {
+  if (auto read = dyn_cast<TransferReadOp>(op)) {
     auto *clone = instantiate(b, read, state->hwVectorType,
                               state->hwVectorInstance, state->substitutionsMap);
     if (!clone) {
@@ -679,7 +679,7 @@ static bool materialize(FuncOp f, const SetVector<Operation *> &terminators,
       continue;
     }
 
-    auto terminator = cast<VectorTransferWriteOp>(term);
+    auto terminator = cast<TransferWriteOp>(term);
     LLVM_DEBUG(dbgs() << "\nFrom terminator:" << *term);
 
     // Get the transitive use-defs starting from terminator, limited to the
@@ -749,7 +749,7 @@ void MaterializeVectorsPass::runOnFunction() {
   // Capture terminators; i.e. vector.transfer_write ops involving a strict
   // super-vector of subVectorType.
   auto filter = [subVectorType](Operation &op) {
-    if (!isa<VectorTransferWriteOp>(op)) {
+    if (!isa<TransferWriteOp>(op)) {
       return false;
     }
     return matcher::operatesOnSuperVectorsOf(op, subVectorType);

--- a/lib/Transforms/Vectorize.cpp
+++ b/lib/Transforms/Vectorize.cpp
@@ -833,7 +833,7 @@ static LogicalResult vectorizeRootOrTerminal(Value *iv,
       return LogicalResult::Failure;
     LLVM_DEBUG(dbgs() << "\n[early-vect]+++++ permutationMap: ");
     LLVM_DEBUG(permutationMap.print(dbgs()));
-    auto transfer = b.create<vector::VectorTransferReadOp>(
+    auto transfer = b.create<vector::TransferReadOp>(
         opInst->getLoc(), vectorType, memoryOp.getMemRef(),
         map(makePtrDynCaster<Value>(), indices),
         AffineMapAttr::get(permutationMap),
@@ -1035,9 +1035,9 @@ static Operation *vectorizeOneOperation(Operation *opInst,
   // Sanity checks.
   assert(!isa<AffineLoadOp>(opInst) &&
          "all loads must have already been fully vectorized independently");
-  assert(!isa<vector::VectorTransferReadOp>(opInst) &&
+  assert(!isa<vector::TransferReadOp>(opInst) &&
          "vector.transfer_read cannot be further vectorized");
-  assert(!isa<vector::VectorTransferWriteOp>(opInst) &&
+  assert(!isa<vector::TransferWriteOp>(opInst) &&
          "vector.transfer_write cannot be further vectorized");
 
   if (auto store = dyn_cast<AffineStoreOp>(opInst)) {
@@ -1064,7 +1064,7 @@ static Operation *vectorizeOneOperation(Operation *opInst,
       return nullptr;
     LLVM_DEBUG(dbgs() << "\n[early-vect]+++++ permutationMap: ");
     LLVM_DEBUG(permutationMap.print(dbgs()));
-    auto transfer = b.create<vector::VectorTransferWriteOp>(
+    auto transfer = b.create<vector::TransferWriteOp>(
         opInst->getLoc(), vectorValue, memRef, indices,
         AffineMapAttr::get(permutationMap));
     auto *res = transfer.getOperation();


### PR DESCRIPTION
Change vector op names from `VectorFooOp` to `Vector_FooOp` and from `vector::VectorFooOp` to `vector::FooOp`.