### PR TITLE
AffineLoopFusion: Prevent fusion of multi-out-edge producer loops

### DIFF
--- a/lib/Transforms/LoopFusion.cpp
+++ b/lib/Transforms/LoopFusion.cpp
@@ -1015,12 +1015,8 @@ static bool canFuseSrcWhichWritesToLiveOut(unsigned srcId, unsigned dstId,
   assert(srcLiveOutStoreOp && "Expected a valid store op");
   auto *dstNode = mdg->getNode(dstId);
   Value *memref = srcLiveOutStoreOp.getMemRef();
-  unsigned memrefNumOutEdges = mdg->getOutEdgeCount(srcId, memref);
-  assert(mdg->getOutEdgeCount(srcId) == memrefNumOutEdges &&
-         "Expected only outgoing edges from memref in srcId");
-
   // Return false if 'srcNode' has more than one output edge on 'memref'.
-  if (memrefNumOutEdges > 1)
+  if (mdg->getOutEdgeCount(srcId, memref) > 1)
     return false;
 
   // Compute MemRefRegion 'srcWriteRegion' for 'srcStoreOp' on 'memref'.

--- a/lib/Transforms/LoopFusion.cpp
+++ b/lib/Transforms/LoopFusion.cpp
@@ -1025,7 +1025,7 @@ static bool canFuseSrcWhichWritesToLiveOut(unsigned srcId, unsigned dstId,
          "Expected only outgoing edges from memref in srcId");
 
   // Return false if 'srcNode' has more than one output edge on 'memref'.
-  if (memrefNumOutEdges != 1)
+  if (memrefNumOutEdges > 1)
     return false;
 
   // Compute MemRefRegion 'srcWriteRegion' for 'srcStoreOp' on 'memref'.

--- a/lib/Transforms/LoopFusion.cpp
+++ b/lib/Transforms/LoopFusion.cpp
@@ -1470,8 +1470,8 @@ public:
   // *) Third pass fuses any remaining producer nodes into their users.
   void run() {
     // TODO(andydavis) Run this repeatedly until a fixed-point is reached.
+    fuseProducerConsumerNodes(/*maxSrcUserCount=*/1);
     if (clSiblingFusion) {
-      fuseProducerConsumerNodes(/*maxSrcUserCount=*/1);
       fuseSiblingNodes();
     }
     fuseProducerConsumerNodes(

--- a/lib/Transforms/LoopFusion.cpp
+++ b/lib/Transforms/LoopFusion.cpp
@@ -57,11 +57,6 @@ static llvm::cl::opt<bool>
                         llvm::cl::desc("Enables maximal loop fusion"),
                         llvm::cl::cat(clOptionsCategory));
 
-static llvm::cl::opt<bool> clSiblingFusion(
-    "sibling-fusion", llvm::cl::init(true),
-    llvm::cl::desc("Enables fusion of sibling loops (enabled by default)"),
-    llvm::cl::cat(clOptionsCategory));
-
 /// A threshold in percent of additional computation allowed when fusing.
 static llvm::cl::opt<double> clFusionAddlComputeTolerance(
     "fusion-compute-tolerance",
@@ -1471,9 +1466,7 @@ public:
   void run() {
     // TODO(andydavis) Run this repeatedly until a fixed-point is reached.
     fuseProducerConsumerNodes(/*maxSrcUserCount=*/1);
-    if (clSiblingFusion) {
-      fuseSiblingNodes();
-    }
+    fuseSiblingNodes();
     fuseProducerConsumerNodes(
         /*maxSrcUserCount=*/std::numeric_limits<unsigned>::max());
     eraseUnusedMemRefAllocations();

--- a/test/Transforms/loop-fusion.mlir
+++ b/test/Transforms/loop-fusion.mlir
@@ -2392,10 +2392,12 @@ func @mul_add_0(%arg0: memref<3x4xf32>, %arg1: memref<4x3xf32>, %arg2: memref<3x
   return
 }
 
+// -----
+
 // Verify that 'fuseProducerConsumerNodes' doesn't fuse a producer loop with
 // multiple outgoing edges. Sibling loop fusion is disabled to properly test
 // producer-consumer fusion in isolation.
-// CHECK-LABEL: func @should_not_fuse_multi_outgoing_edge_store_producer
+// NOSIBLING-LABEL: func @should_not_fuse_multi_outgoing_edge_store_producer
 func @should_not_fuse_multi_outgoing_edge_store_producer() {
   %cst = constant 0.000000e+00 : f32
   %0 = alloc() : memref<1xf32>


### PR DESCRIPTION
In https://github.com/tensorflow/mlir/pull/162 I introduced a bug that
incorrectly allowed fusion of producer loops with multiple outgoing
edges. This commit fixes that problem. It also introduces a new flag to
disable sibling loop fusion so that we can test producer-consumer fusion
in isolation.