### PR TITLE
[spirv] Check that operand of `spirv::CompositeExtractOp` is constant while folding.

### DIFF
--- a/lib/Dialect/SPIRV/SPIRVOps.cpp
+++ b/lib/Dialect/SPIRV/SPIRVOps.cpp
@@ -336,6 +336,9 @@ static void printVariableDecorations(Operation *op, OpAsmPrinter &printer,
 // `indices`. Returns a null Attribute if error happens.
 static Attribute extractCompositeElement(Attribute composite,
                                          ArrayRef<unsigned> indices) {
+  // Check that given composite is a constant.
+  if (!composite)
+    return {};
   // Return composite itself if we reach the end of the index chain.
   if (indices.empty())
     return composite;

--- a/test/Dialect/SPIRV/canonicalize.mlir
+++ b/test/Dialect/SPIRV/canonicalize.mlir
@@ -126,6 +126,17 @@ func @extract_array_interm() -> (vector<2xi32>) {
 
 // -----
 
+// CHECK-LABEL: extract_from_not_constant
+func @extract_from_not_constant() -> i32 {
+  %0 = spv.Variable : !spv.ptr<vector<3xi32>, Function>
+  %1 = spv.Load "Function" %0 : vector<3xi32>
+  // CHECK: spv.CompositeExtract
+  %2 = spv.CompositeExtract %1[0 : i32] : vector<3xi32>
+  spv.ReturnValue %2 : i32
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // spv.constant
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This patch addresses an issue https://github.com/tensorflow/mlir/issues/269
Add a check that operand of `spirv::CompositeExtractOp` is constant while folding.
@antiagainst @MaheshRavishankar can you please take a look, thanks!
