### PR TITLE
Fixed difference in docs tutorial #1

### DIFF
--- a/g3doc/Tutorials/Toy/Ch-1.md
+++ b/g3doc/Tutorials/Toy/Ch-1.md
@@ -53,7 +53,7 @@ nothing is better than walking through an example to get a better understanding:
 
 ```Toy {.toy}
 def main() {
-  # Define a variable `a` with shape <2, 3>, initialized with the literal value.
+  # Define a variable `a` with shape <3, 2>, initialized with the literal value.
   # The shape is inferred from the supplied literal.
   var a = [[1, 2, 3], [4, 5, 6]];
 
@@ -62,7 +62,7 @@ def main() {
   var b<2, 3> = [1, 2, 3, 4, 5, 6];
 
   # transpose() and print() are the only builtin, the following will transpose
-  # b and perform an element-wise multiplication before printing the result.
+  # a and b and perform an element-wise multiplication before printing the result.
   print(transpose(a) * transpose(b));
 }
 ```

--- a/g3doc/Tutorials/Toy/Ch-1.md
+++ b/g3doc/Tutorials/Toy/Ch-1.md
@@ -53,7 +53,7 @@ nothing is better than walking through an example to get a better understanding:
 
 ```Toy {.toy}
 def main() {
-  # Define a variable `a` with shape <3, 2>, initialized with the literal value.
+  # Define a variable `a` with shape <2, 3>, initialized with the literal value.
   # The shape is inferred from the supplied literal.
   var a = [[1, 2, 3], [4, 5, 6]];
 


### PR DESCRIPTION
annotation explains only transpose(b), however, transpose(a) also contains.