### PR TITLE
NFC - fix name / comments - isAccessInvariant -> isAccessIndexInvariant

### DIFF
--- a/include/mlir/Analysis/LoopAnalysis.h
+++ b/include/mlir/Analysis/LoopAnalysis.h
@@ -56,23 +56,6 @@ llvm::Optional<uint64_t> getConstantTripCount(AffineForOp forOp);
 /// this method is thus able to determine non-trivial divisors.
 uint64_t getLargestDivisorOfTripCount(AffineForOp forOp);
 
-/// Given an induction variable `iv` of type AffineForOp and an `index` of type
-/// IndexType, returns `true` if `index` is independent of `iv` and false
-/// otherwise.
-/// The determination supports composition with at most one AffineApplyOp.
-/// The at most one AffineApplyOp comes from the fact that composition of
-/// AffineApplyOp need to be canonicalized by construction to avoid writing code
-/// that composes arbitrary numbers of AffineApplyOps everywhere. To achieve
-/// this, at the very least, the compose-affine-apply pass must have been run.
-///
-/// Prerequisites:
-///   1. `iv` and `index` of the proper type;
-///   2. at most one reachable AffineApplyOp from index;
-///
-/// Returns false in cases with more than one AffineApplyOp, this is
-/// conservative.
-bool isAccessInvariant(Value *iv, Value *index);
-
 /// Given an induction variable `iv` of type AffineForOp and `indices` of type
 /// IndexType, returns the set of `indices` that are independent of `iv`.
 ///

--- a/lib/Analysis/LoopAnalysis.cpp
+++ b/lib/Analysis/LoopAnalysis.cpp
@@ -159,7 +159,22 @@ uint64_t mlir::getLargestDivisorOfTripCount(AffineForOp forOp) {
   return gcd.getValue();
 }
 
-bool mlir::isAccessInvariant(Value *iv, Value *index) {
+/// Given an induction variable `iv` of type AffineForOp and an access `index`
+/// of type index, returns `true` if `index` is independent of `iv` and
+/// false otherwise. The determination supports composition with at most one
+/// AffineApplyOp. The 'at most one AffineApplyOp' comes from the fact that
+/// the composition of AffineApplyOp needs to be canonicalized by construction
+/// to avoid writing code that composes arbitrary numbers of AffineApplyOps
+/// everywhere. To achieve this, at the very least, the compose-affine-apply
+/// pass must have been run.
+///
+/// Prerequisites:
+///   1. `iv` and `index` of the proper type;
+///   2. at most one reachable AffineApplyOp from index;
+///
+/// Returns false in cases with more than one AffineApplyOp, this is
+/// conservative.
+static bool isAccessIndexInvariant(Value *iv, Value *index) {
   assert(isForInductionVar(iv) && "iv must be a AffineForOp");
   assert(index->getType().isa<IndexType>() && "index must be of IndexType");
   SmallVector<Operation *, 4> affineApplyOps;
@@ -188,7 +203,7 @@ mlir::getInvariantAccesses(Value *iv, llvm::ArrayRef<Value *> indices) {
   llvm::DenseSet<Value *> res;
   for (unsigned idx = 0, n = indices.size(); idx < n; ++idx) {
     auto *val = indices[idx];
-    if (isAccessInvariant(iv, val)) {
+    if (isAccessIndexInvariant(iv, val)) {
       res.insert(val);
     }
   }
@@ -250,7 +265,7 @@ static bool isContiguousAccess(Value *iv, LoadOrStoreOp memoryOp,
     });
     // Check access invariance of each operand in 'exprOperands'.
     for (auto *exprOperand : exprOperands) {
-      if (!isAccessInvariant(iv, exprOperand)) {
+      if (!isAccessIndexInvariant(iv, exprOperand)) {
         if (uniqueVaryingIndexAlongIv != -1) {
           // 2+ varying indices -> do not vectorize along iv.
           return false;


### PR DESCRIPTION
- the name was misleading; this is really checking if a Value being used
  to index was loop IV invariant. Update comment.

- the method is only used locally; what can be exposed in the future is
  isAccessInvariant(LoadOrStoreOp op, Value *iv)

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>