### PR TITLE
NFC - minor spelling tweaks 

### DIFF
--- a/examples/toy/Ch2/include/toy/Ops.td
+++ b/examples/toy/Ch2/include/toy/Ops.td
@@ -49,7 +49,7 @@ class Toy_Op<string mnemonic, list<OpTrait> traits = []> :
 // and may be removed if dead.
 def ConstantOp : Toy_Op<"constant", [NoSideEffect]> {
   // Provide a summary and description for this operation. This can be used to
-  // auto-generate documenatation of the operations within our dialect.
+  // auto-generate documentation of the operations within our dialect.
   let summary = "constant";
   let description = [{
     Constant operation turns a literal into an SSA value. The data is attached

--- a/examples/toy/Ch3/include/toy/Ops.td
+++ b/examples/toy/Ch3/include/toy/Ops.td
@@ -49,7 +49,7 @@ class Toy_Op<string mnemonic, list<OpTrait> traits = []> :
 // and may be removed if dead.
 def ConstantOp : Toy_Op<"constant", [NoSideEffect]> {
   // Provide a summary and description for this operation. This can be used to
-  // auto-generate documenatation of the operations within our dialect.
+  // auto-generate documentation of the operations within our dialect.
   let summary = "constant";
   let description = [{
     Constant operation turns a literal into an SSA value. The data is attached

--- a/examples/toy/Ch4/include/toy/Ops.td
+++ b/examples/toy/Ch4/include/toy/Ops.td
@@ -50,7 +50,7 @@ class Toy_Op<string mnemonic, list<OpTrait> traits = []> :
 // and may be removed if dead.
 def ConstantOp : Toy_Op<"constant", [NoSideEffect]> {
   // Provide a summary and description for this operation. This can be used to
-  // auto-generate documenatation of the operations within our dialect.
+  // auto-generate documentation of the operations within our dialect.
   let summary = "constant";
   let description = [{
     Constant operation turns a literal into an SSA value. The data is attached

--- a/examples/toy/Ch5/include/toy/Ops.td
+++ b/examples/toy/Ch5/include/toy/Ops.td
@@ -50,7 +50,7 @@ class Toy_Op<string mnemonic, list<OpTrait> traits = []> :
 // and may be removed if dead.
 def ConstantOp : Toy_Op<"constant", [NoSideEffect]> {
   // Provide a summary and description for this operation. This can be used to
-  // auto-generate documenatation of the operations within our dialect.
+  // auto-generate documentation of the operations within our dialect.
   let summary = "constant";
   let description = [{
     Constant operation turns a literal into an SSA value. The data is attached

--- a/examples/toy/Ch6/include/toy/Ops.td
+++ b/examples/toy/Ch6/include/toy/Ops.td
@@ -50,7 +50,7 @@ class Toy_Op<string mnemonic, list<OpTrait> traits = []> :
 // and may be removed if dead.
 def ConstantOp : Toy_Op<"constant", [NoSideEffect]> {
   // Provide a summary and description for this operation. This can be used to
-  // auto-generate documenatation of the operations within our dialect.
+  // auto-generate documentation of the operations within our dialect.
   let summary = "constant";
   let description = [{
     Constant operation turns a literal into an SSA value. The data is attached

--- a/examples/toy/Ch7/include/toy/Ops.td
+++ b/examples/toy/Ch7/include/toy/Ops.td
@@ -59,7 +59,7 @@ def Toy_Type : AnyTypeOf<[F64Tensor, Toy_StructType]>;
 def ConstantOp : Toy_Op<"constant",
     [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
   // Provide a summary and description for this operation. This can be used to
-  // auto-generate documenatation of the operations within our dialect.
+  // auto-generate documentation of the operations within our dialect.
   let summary = "constant";
   let description = [{
     Constant operation turns a literal into an SSA value. The data is attached

--- a/examples/toy/Ch7/include/toy/Parser.h
+++ b/examples/toy/Ch7/include/toy/Parser.h
@@ -613,7 +613,7 @@ private:
   /// `struct` keyword, followed by a block containing a list of variable
   /// declarations.
   ///
-  /// definition ::= `struct` identifer `{` decl+ `}`
+  /// definition ::= `struct` identifier `{` decl+ `}`
   std::unique_ptr<StructAST> parseStruct() {
     auto loc = lexer.getLastLocation();
     lexer.consume(tok_struct);

--- a/g3doc/Traits.md
+++ b/g3doc/Traits.md
@@ -78,7 +78,7 @@ Traits may be used when defining a derived operation type, by simply adding the
 name of the trait class to the `Op` class after the concrete operation type:
 
 ```c++
-/// Here we define 'MyOp' along with the 'MyTrait' and `MyParameteric trait
+/// Here we define 'MyOp' along with the 'MyTrait' and `MyParametric trait
 /// classes we defined previously.
 class MyOp : public Op<MyOp, MyTrait, MyParametricTrait<10>::Impl> {};
 ```

--- a/include/mlir/Dialect/GPU/GPUOps.td
+++ b/include/mlir/Dialect/GPU/GPUOps.td
@@ -154,7 +154,7 @@ def GPU_GPUFuncOp : GPU_Op<"func", [FunctionLike, IsolatedFromAbove, Symbol]> {
     /// Returns the name of the attribute containing the number of buffers
     /// located in the workgroup memory.
     static StringRef getNumWorkgroupAttributionsAttrName() {
-      return "workgroup_attibutions";
+      return "workgroup_attributions";
     }
 
     // FunctionLike trait needs access to the functions below.

--- a/include/mlir/Dialect/SPIRV/LayoutUtils.h
+++ b/include/mlir/Dialect/SPIRV/LayoutUtils.h
@@ -63,7 +63,7 @@ public:
   /// Checks whether a type is legal in terms of Vulkan layout info
   /// decoration. A type is dynamically illegal if it's a composite type in the
   /// StorageBuffer, PhysicalStorageBuffer, Uniform, and PushConstant Storage
-  /// Classes without layout informtation.
+  /// Classes without layout information.
   static bool isLegalType(Type type);
 
 private:

--- a/include/mlir/Dialect/SPIRV/SPIRVBitOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVBitOps.td
@@ -193,7 +193,7 @@ def SPV_BitFieldSExtractOp : SPV_BitFieldExtractOp<"BitFieldSExtract", []> {
     ``` {.ebnf}
     integer-scalar-vector-type ::= integer-type |
                                   `vector<` integer-literal `x` integer-type `>`
-    bitfield-exctact-s-op ::= ssa-id `=` `spv.BitFieldSExtract` ssa-use
+    bitfield-extract-s-op ::= ssa-id `=` `spv.BitFieldSExtract` ssa-use
                                          `,` ssa-use `,` ssa-use
                                          `:` integer-scalar-vector-type
                                          `,` integer-type `,` integer-type
@@ -222,7 +222,7 @@ def SPV_BitFieldUExtractOp : SPV_BitFieldExtractOp<"BitFieldUExtract", []> {
     ``` {.ebnf}
     integer-scalar-vector-type ::= integer-type |
                                   `vector<` integer-literal `x` integer-type `>`
-    bitfield-exctact-u-op ::= ssa-id `=` `spv.BitFieldUExtract` ssa-use
+    bitfield-extract-u-op ::= ssa-id `=` `spv.BitFieldUExtract` ssa-use
                                          `,` ssa-use `,` ssa-use
                                          `:` integer-scalar-vector-type
                                          `,` integer-type `,` integer-type

--- a/include/mlir/Dialect/SPIRV/SPIRVLowering.h
+++ b/include/mlir/Dialect/SPIRV/SPIRVLowering.h
@@ -30,7 +30,7 @@
 
 namespace mlir {
 
-/// Type conversion from stdandard types to SPIR-V types for shader interface.
+/// Type conversion from standard types to SPIR-V types for shader interface.
 ///
 /// For composite types, this converter additionally performs type wrapping to
 /// satisfy shader interface requirements: shader interface types must be
@@ -39,10 +39,10 @@ class SPIRVTypeConverter final : public TypeConverter {
 public:
   using TypeConverter::TypeConverter;
 
-  /// Converts the given standard `type` to SPIR-V correspondance.
+  /// Converts the given standard `type` to SPIR-V correspondence.
   Type convertType(Type type) override;
 
-  /// Gets the SPIR-V correspondance for the standard index type.
+  /// Gets the SPIR-V correspondence for the standard index type.
   static Type getIndexType(MLIRContext *context);
 };
 

--- a/include/mlir/Dialect/SPIRV/SPIRVOps.td
+++ b/include/mlir/Dialect/SPIRV/SPIRVOps.td
@@ -392,7 +392,7 @@ def SPV_UndefOp : SPV_Op<"undef", []> {
     ### Custom assembly form
 
     ``` {.ebnf}
-    undef-op ::= `spv.undef` `:` sprirv-type
+    undef-op ::= `spv.undef` `:` spirv-type
     ```
 
     For example:

--- a/include/mlir/Dialect/StandardOps/Ops.h
+++ b/include/mlir/Dialect/StandardOps/Ops.h
@@ -190,7 +190,7 @@ public:
   unsigned getSrcMemRefRank() {
     return getSrcMemRef()->getType().cast<MemRefType>().getRank();
   }
-  // Returns the source memerf indices for this DMA operation.
+  // Returns the source memref indices for this DMA operation.
   operand_range getSrcIndices() {
     return {getOperation()->operand_begin() + 1,
             getOperation()->operand_begin() + 1 + getSrcMemRefRank()};

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -1236,7 +1236,7 @@ def SubViewOp : Std_Op<"subview", [AttrSizedOperandSegments, NoSideEffect]> {
         : memref<?x?xf32, (d0, d1)[s0, s1, s2] -> (d0 * s1 + d1 * s2 + s0)> to
           memref<4x4xf32, (d0, d1)[r0, r1, r2] -> (d0 * r1 + d1 * r2 + r0)>
 
-      // Note that the subview op does not gaurantee that the result
+      // Note that the subview op does not guarantee that the result
       // memref is "inbounds" w.r.t to base memref. It is upto the client
       // to ensure that the subview is accessed in a manner that is
       // in-bounds.

--- a/include/mlir/Dialect/VectorOps/VectorOps.td
+++ b/include/mlir/Dialect/VectorOps/VectorOps.td
@@ -197,7 +197,7 @@ def Vector_BroadcastOp :
                <duplication>         <potential stretch>
        ```
     The source operand is duplicated over all the missing leading dimensions
-    and streched over the trailing dimensions where the source has a non-equal
+    and stretched over the trailing dimensions where the source has a non-equal
     dimension of 1. These rules imply that any scalar broadcast (k=0) to any
     shaped vector with the same element type is always legal.
 
@@ -649,7 +649,7 @@ def Vector_ConstantMaskOp :
     are set to '0' or '1', based on whether the element indices are contained
     within a hyper-rectangular region specified by the 'mask_dim_sizes'
     array attribute argument. Each element of the 'mask_dim_sizes' array,
-    specifices an exclusive upper bound [0, mask-dim-size-element-value)
+    specifies an exclusive upper bound [0, mask-dim-size-element-value)
     for a unique dimension in the vector result. The conjunction of the ranges
     define a hyper-rectangular region within which elements values are set to 1
     (otherwise element values are set to 0).

--- a/include/mlir/EDSC/Builders.h
+++ b/include/mlir/EDSC/Builders.h
@@ -209,7 +209,7 @@ private:
 /// ```
 class AffineLoopNestBuilder {
 public:
-  // This entry point accomodates the fact that AffineForOp implicitly uses
+  // This entry point accommodates the fact that AffineForOp implicitly uses
   // multiple `lbs` and `ubs` with one single `iv` and `step` to encode `max`
   // and and `min` constraints respectively.
   AffineLoopNestBuilder(ValueHandle *iv, ArrayRef<ValueHandle> lbs,

--- a/include/mlir/IR/Dialect.h
+++ b/include/mlir/IR/Dialect.h
@@ -308,7 +308,7 @@ template <typename ConcreteDialect> void registerDialect() {
   });
 }
 
-/// DialectRegistration provides a global initialiser that registers a Dialect
+/// DialectRegistration provides a global initializer that registers a Dialect
 /// allocation routine.
 ///
 /// Usage:

--- a/include/mlir/IR/DialectHooks.h
+++ b/include/mlir/IR/DialectHooks.h
@@ -50,7 +50,7 @@ public:
 /// based on information coming from DialectHooksRegistration.
 void registerDialectHooksSetter(const DialectHooksSetter &function);
 
-/// DialectHooksRegistration provides a global initialiser that registers
+/// DialectHooksRegistration provides a global initializer that registers
 /// a dialect hooks setter routine.
 /// Usage:
 ///

--- a/include/mlir/IR/SymbolTable.h
+++ b/include/mlir/IR/SymbolTable.h
@@ -127,7 +127,7 @@ public:
   /// of the symbol table, and not the op itself. This function will also return
   /// false if there are any unknown operations that may potentially be symbol
   /// tables. This doesn't necessarily mean that there are no uses, we just
-  /// can't convervatively prove it.
+  /// can't conservatively prove it.
   static bool symbolKnownUseEmpty(StringRef symbol, Operation *from);
 
   /// Attempt to replace all uses of the given symbol 'oldSymbol' with the

--- a/include/mlir/Pass/PassManager.h
+++ b/include/mlir/Pass/PassManager.h
@@ -97,7 +97,7 @@ public:
   /// Returns the internal implementation instance.
   detail::OpPassManagerImpl &getImpl();
 
-  /// Prints out the passes of the pass mangager as the textual representation
+  /// Prints out the passes of the pass manager as the textual representation
   /// of pipelines.
   /// Note: The quality of the string representation depends entirely on the
   /// the correctness of per-pass overrides of Pass::printAsTextualPipeline.

--- a/include/mlir/TableGen/Format.h
+++ b/include/mlir/TableGen/Format.h
@@ -44,7 +44,7 @@ namespace tblgen {
 /// named as $<name>, and we can potentially support referencing those entities
 /// directly in the format template in the future.
 //
-/// Custom ones are registered by dialect-specific TablGen backends and use the
+/// Custom ones are registered by dialect-specific TableGen backends and use the
 /// same unified setter.
 class FmtContext {
 public:

--- a/include/mlir/TableGen/Pattern.h
+++ b/include/mlir/TableGen/Pattern.h
@@ -338,7 +338,7 @@ public:
                              const char *separator = ", ") const;
 
   // Splits the given `symbol` into a value pack name and an index. Returns the
-  // value pack name and writes the index to `index` on sucess. Returns `symbol`
+  // value pack name and writes the index to `index` on success. Returns `symbol`
   // itself if it does not contain an index.
   //
   // We can use `name__N` to access the `N`-th value in the value pack bound to

--- a/include/mlir/Translation.h
+++ b/include/mlir/Translation.h
@@ -64,7 +64,7 @@ using TranslateFromMLIRFunction =
 using TranslateFunction = std::function<LogicalResult(
     llvm::SourceMgr &sourceMgr, llvm::raw_ostream &output, MLIRContext *)>;
 
-/// Use Translate[ToMLIR|FromMLIR]Registration as a global initialiser that
+/// Use Translate[ToMLIR|FromMLIR]Registration as a global initializer that
 /// registers a function and associates it with name. This requires that a
 /// translation has not been registered to a given name.
 ///

--- a/lib/Analysis/Utils.cpp
+++ b/lib/Analysis/Utils.cpp
@@ -151,7 +151,7 @@ LogicalResult MemRefRegion::unionBoundingBox(const MemRefRegion &other) {
 }
 
 /// Computes the memory region accessed by this memref with the region
-/// represented as constraints symbolic/parameteric in 'loopDepth' loops
+/// represented as constraints symbolic/parametric in 'loopDepth' loops
 /// surrounding opInst and any additional Function symbols.
 //  For example, the memref region for this load operation at loopDepth = 1 will
 //  be as below:

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -610,12 +610,12 @@ struct NDVectorTypeInfo {
 } // namespace
 
 // For >1-D vector types, extracts the necessary information to iterate over all
-// 1-D subvectors in the underlying llrepresentation of the n-D vecotr
+// 1-D subvectors in the underlying llrepresentation of the n-D vector
 // Iterates on the llvm array type until we hit a non-array type (which is
 // asserted to be an llvm vector type).
 static NDVectorTypeInfo extractNDVectorTypeInfo(VectorType vectorType,
                                                 LLVMTypeConverter &converter) {
-  assert(vectorType.getRank() > 1 && "extpected >1D vector type");
+  assert(vectorType.getRank() > 1 && "expected >1D vector type");
   NDVectorTypeInfo info;
   info.llvmArrayTy =
       converter.convertType(vectorType).dyn_cast<LLVM::LLVMType>();
@@ -1240,7 +1240,7 @@ struct MemRefCastOpLowering : public LLVMLegalizationPattern<MemRefCastOp> {
     } else if (srcType.isa<MemRefType>() && dstType.isa<UnrankedMemRefType>()) {
       // Casting ranked to unranked memref type
       // Set the rank in the destination from the memref type
-      // Allocate space on the stack and copy the src memref decsriptor
+      // Allocate space on the stack and copy the src memref descriptor
       // Set the ptr in the destination to the stack space
       auto srcMemRefType = srcType.cast<MemRefType>();
       int64_t rank = srcMemRefType.getRank();

--- a/lib/Dialect/SPIRV/Serialization/Serializer.cpp
+++ b/lib/Dialect/SPIRV/Serialization/Serializer.cpp
@@ -450,7 +450,7 @@ private:
   /// But we don't know the <id> for %val0 and %val1 yet. One way is to visit
   /// all the blocks twice and use the first visit to assign an <id> to each
   /// value. But it's paying the overheads just for OpPhi emission. Instead,
-  /// we still visit the blocks once for emssion. When we emit the OpPhi
+  /// we still visit the blocks once for emission. When we emit the OpPhi
   /// instructions, we use 0 as a placeholder for the <id>s for %val0 and %val1.
   /// At the same time, we record their offsets in the emitted binary (which is
   /// placed inside `functions`) here. And then after emitting all blocks, we

--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -279,7 +279,7 @@ MLIRContext *OpPassManager::getContext() const {
 /// Return the operation name that this pass manager operates on.
 const OperationName &OpPassManager::getOpName() const { return impl->name; }
 
-/// Prints out the passes of the pass mangager as the textual representation
+/// Prints out the passes of the pass manager as the textual representation
 /// of pipelines.
 void OpPassManager::printAsTextualPipeline(raw_ostream &os) {
   // Filter out passes that are not part of the public pipeline.

--- a/lib/Pass/PassStatistics.cpp
+++ b/lib/Pass/PassStatistics.cpp
@@ -178,7 +178,7 @@ Pass::Statistic::Statistic(Pass *owner, const char *name,
   // Always set the 'initialized' bit to true so that this statistic isn't
   // placed in the static registry.
   // TODO: This is sort of hack as `llvm::Statistic`s can't be setup to avoid
-  // automatic registartion with the global registry. We should either add
+  // automatic registration with the global registry. We should either add
   // support for this in LLVM, or just write our own statistics classes.
   Initialized = true;
 #endif

--- a/lib/Transforms/LoopTiling.cpp
+++ b/lib/Transforms/LoopTiling.cpp
@@ -362,7 +362,7 @@ void LoopTiling::getTileSizes(ArrayRef<AffineForOp> band,
   // one possible approach. Or compute a polynomial in tile sizes and solve for
   // it.
 
-  // For an n-d tilable band, compute n^th root of the excess.
+  // For an n-d tileable band, compute n^th root of the excess.
   unsigned tSize =
       static_cast<unsigned>(floorl(std::pow(excessFactor, 1.0 / band.size())));
   // We'll keep a running product to determine the last tile size better.

--- a/lib/Transforms/Utils/LoopUtils.cpp
+++ b/lib/Transforms/Utils/LoopUtils.cpp
@@ -933,7 +933,7 @@ static LogicalResult tryIsolateBands(const TileLoops &tileLoops) {
 
 TileLoops mlir::extractFixedOuterLoops(loop::ForOp rootForOp,
                                        ArrayRef<int64_t> sizes) {
-  // Collect prefectly nested loops.  If more size values provided than nested
+  // Collect perfectly nested loops.  If more size values provided than nested
   // loops available, truncate `sizes`.
   SmallVector<loop::ForOp, 4> forOps;
   forOps.reserve(sizes.size());

--- a/lib/Transforms/Utils/Utils.cpp
+++ b/lib/Transforms/Utils/Utils.cpp
@@ -70,7 +70,7 @@ LogicalResult mlir::replaceAllMemRefUsesWith(Value *oldMemRef, Value *newMemRef,
   (void)oldMemRefRank; // unused in opt mode
   if (indexRemap) {
     assert(indexRemap.getNumSymbols() == symbolOperands.size() &&
-           "symbolic operand count mistmatch");
+           "symbolic operand count mismatch");
     assert(indexRemap.getNumInputs() ==
            extraOperands.size() + oldMemRefRank + symbolOperands.size());
     assert(indexRemap.getNumResults() + extraIndices.size() == newMemRefRank);

--- a/test/Conversion/StandardToLLVM/standard-to-llvm.mlir
+++ b/test/Conversion/StandardToLLVM/standard-to-llvm.mlir
@@ -20,7 +20,7 @@ func @strided_memref(%ind: index) {
 // -----
 
 // This should not crash. The first operation cannot be converted, so the
-// secound should not match. This attempts to convert `return` to `llvm.return`
+// second should not match. This attempts to convert `return` to `llvm.return`
 // and complains about non-LLVM types.
 func @unknown_source() -> i32 {
   %0 = "foo"() : () -> i32

--- a/test/Dialect/Linalg/llvm.mlir
+++ b/test/Dialect/Linalg/llvm.mlir
@@ -108,7 +108,7 @@ func @copy_transpose(%arg0: memref<?x?x?xf32, offset: ?, strides: [?, ?, 1]>, %a
   return
 }
 // CHECK-LABEL: func @copy
-// Tranpose input
+// Transpose input
 //         CHECK:   llvm.insertvalue {{.*}}[0] : !llvm<"{ float*, float*, i64, [3 x i64], [3 x i64] }">
 //         CHECK:    llvm.insertvalue {{.*}}[1] : !llvm<"{ float*, float*, i64, [3 x i64], [3 x i64] }">
 //         CHECK:    llvm.insertvalue {{.*}}[2] : !llvm<"{ float*, float*, i64, [3 x i64], [3 x i64] }">

--- a/test/Dialect/SPIRV/Serialization/bit-ops.mlir
+++ b/test/Dialect/SPIRV/Serialization/bit-ops.mlir
@@ -36,7 +36,7 @@ spv.module "Logical" "GLSL450" {
     %0 = spv.ShiftLeftLogical %arg0, %arg1: i32, i16
     spv.ReturnValue %0 : i32
   }
-  func @shift_right_aritmethic(%arg0: vector<4xi32>, %arg1 : vector<4xi8>) -> vector<4xi32> {
+  func @shift_right_arithmetic(%arg0: vector<4xi32>, %arg1 : vector<4xi8>) -> vector<4xi32> {
     // CHECK: {{%.*}} = spv.ShiftRightArithmetic {{%.*}}, {{%.*}} : vector<4xi32>, vector<4xi8>
     %0 = spv.ShiftRightArithmetic %arg0, %arg1: vector<4xi32>, vector<4xi8>
     spv.ReturnValue %0 : vector<4xi32>

--- a/test/Dialect/SPIRV/canonicalize.mlir
+++ b/test/Dialect/SPIRV/canonicalize.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s -split-input-file -pass-pipeline='func(canonicalize)' | FileCheck %s
 
 //===----------------------------------------------------------------------===//
-// spv.AccsessChain
+// spv.AccessChain
 //===----------------------------------------------------------------------===//
 
 func @combine_full_access_chain() -> f32 {

--- a/test/Dialect/SPIRV/ops.mlir
+++ b/test/Dialect/SPIRV/ops.mlir
@@ -927,7 +927,7 @@ func @shift_left_logical_invalid_result_type(%arg0: i32, %arg1 : i16) -> i16 {
 // spv.ShiftRightArithmetic
 //===----------------------------------------------------------------------===//
 
-func @shift_right_aritmethic(%arg0: vector<4xi32>, %arg1 : vector<4xi8>) -> vector<4xi32> {
+func @shift_right_arithmetic(%arg0: vector<4xi32>, %arg1 : vector<4xi8>) -> vector<4xi32> {
   // CHECK: {{%.*}} = spv.ShiftRightArithmetic {{%.*}}, {{%.*}} : vector<4xi32>, vector<4xi8>
   %0 = spv.ShiftRightArithmetic %arg0, %arg1: vector<4xi32>, vector<4xi8>
   spv.ReturnValue %0 : vector<4xi32>

--- a/test/Transforms/loop-fusion-slice-computation.mlir
+++ b/test/Transforms/loop-fusion-slice-computation.mlir
@@ -42,7 +42,7 @@ func @slice_depth1_loop_nest_with_offsets() {
 // -----
 
 // Slices at loop depth 1 should only slice the loop bounds of the first loop.
-// Slices at loop detph 2 should slice loop bounds of both loops.
+// Slices at loop depth 2 should slice loop bounds of both loops.
 // CHECK-LABEL: func @slice_depth2_loop_nest() {
 func @slice_depth2_loop_nest() {
   %0 = alloc() : memref<100x100xf32>

--- a/test/lib/TestDialect/TestOps.td
+++ b/test/lib/TestDialect/TestOps.td
@@ -916,10 +916,10 @@ def MixedVResultOp3 : TEST_Op<"mixed_variadic_out3",
       "Builder *builder, OperationState &state, IntegerAttr count",
       [{
         auto i32Type = builder->getIntegerType(32);
-        state.addTypes(i32Type); // $ouput1
+        state.addTypes(i32Type); // $output1
         SmallVector<Type, 4> types(count.getInt(), i32Type);
-        state.addTypes(types); // $ouput2
-        state.addTypes(types); // $ouput3
+        state.addTypes(types); // $output2
+        state.addTypes(types); // $output3
         state.addAttribute("count", count);
       }]>
   ];

--- a/tools/mlir-tblgen/DocGenUtilities.h
+++ b/tools/mlir-tblgen/DocGenUtilities.h
@@ -15,7 +15,7 @@
 // limitations under the License.
 // =============================================================================
 //
-// This file defines common utilities for generating documents from tablgen
+// This file defines common utilities for generating documents from tablegen
 // structures.
 //
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR addresses recent spelling tweaks, especially in `.c/.h/.td` files.