### PR TITLE
Avoid unnecessary SmallVector constructions

### DIFF
--- a/include/mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h
+++ b/include/mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h
@@ -75,8 +75,8 @@ public:
   /// and use pointers to struct to avoid the complexity of the
   /// platform-specific C/C++ ABI lowering related to struct argument passing.
   SmallVector<Value *, 4> promoteMemRefDescriptors(Location loc,
-                                                   ArrayRef<Value *> opOperands,
-                                                   ArrayRef<Value *> operands,
+                                                   ValueRange opOperands,
+                                                   ValueRange operands,
                                                    OpBuilder &builder);
 
   /// Promote the LLVM struct representation of one MemRef descriptor to stack

--- a/include/mlir/IR/OperationSupport.h
+++ b/include/mlir/IR/OperationSupport.h
@@ -274,7 +274,7 @@ public:
 
   OperationState(Location location, OperationName name);
 
-  OperationState(Location location, StringRef name, ArrayRef<Value *> operands,
+  OperationState(Location location, StringRef name, ValueRange operands,
                  ArrayRef<Type> types, ArrayRef<NamedAttribute> attributes,
                  ArrayRef<Block *> successors = {},
                  MutableArrayRef<std::unique_ptr<Region>> regions = {},

--- a/lib/Analysis/AffineStructures.cpp
+++ b/lib/Analysis/AffineStructures.cpp
@@ -659,9 +659,8 @@ LogicalResult FlatAffineConstraints::composeMap(const AffineValueMap *vMap) {
 
   // Add localCst information.
   if (localCst.getNumLocalIds() > 0) {
-    SmallVector<Value *, 8> values(vMap->getOperands().begin(),
-                                   vMap->getOperands().end());
-    localCst.setIdValues(0, localCst.getNumDimAndSymbolIds(), values);
+    localCst.setIdValues(0, /*end=*/localCst.getNumDimAndSymbolIds(),
+                         /*values=*/vMap->getOperands());
     // Align localCst and this.
     mergeAndAlignIds(/*offset=*/0, &localCst, this);
     // Finally, append localCst to this constraint set.

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -1110,9 +1110,8 @@ struct CallOpInterfaceLowering : public LLVMLegalizationPattern<CallOpType> {
         return this->matchFailure();
     }
 
-    SmallVector<Value *, 4> opOperands(op->getOperands());
     auto promoted = this->lowering.promoteMemRefDescriptors(
-        op->getLoc(), opOperands, operands, rewriter);
+        op->getLoc(), /*opOperands=*/op->getOperands(), operands, rewriter);
     auto newOp = rewriter.create<LLVM::CallOp>(op->getLoc(), packedResult,
                                                promoted, op->getAttrs());
 
@@ -2079,7 +2078,7 @@ Value *LLVMTypeConverter::promoteOneMemRefDescriptor(Location loc,
 }
 
 SmallVector<Value *, 4> LLVMTypeConverter::promoteMemRefDescriptors(
-    Location loc, ArrayRef<Value *> opOperands, ArrayRef<Value *> operands,
+    Location loc, ValueRange opOperands, ValueRange operands,
     OpBuilder &builder) {
   SmallVector<Value *, 4> promotedOperands;
   promotedOperands.reserve(operands.size());

--- a/lib/IR/OperationSupport.cpp
+++ b/lib/IR/OperationSupport.cpp
@@ -36,7 +36,7 @@ OperationState::OperationState(Location location, OperationName name)
     : location(location), name(name) {}
 
 OperationState::OperationState(Location location, StringRef name,
-                               ArrayRef<Value *> operands, ArrayRef<Type> types,
+                               ValueRange operands, ArrayRef<Type> types,
                                ArrayRef<NamedAttribute> attributes,
                                ArrayRef<Block *> successors,
                                MutableArrayRef<std::unique_ptr<Region>> regions,

--- a/lib/Transforms/Utils/LoopUtils.cpp
+++ b/lib/Transforms/Utils/LoopUtils.cpp
@@ -1235,11 +1235,10 @@ static AffineForOp generatePointWiseCopy(Location loc, Value *memref,
                   memIndicesStart);
 
     // Construct the subscript for the slow memref being copied.
-    SmallVector<Value *, 2> operands = {memBase, forOp.getInductionVar()};
     auto memIndex = b.create<AffineApplyOp>(
         loc,
         AffineMap::get(2, 0, b.getAffineDimExpr(0) + b.getAffineDimExpr(1)),
-        operands);
+        ValueRange({memBase, forOp.getInductionVar()}));
     memIndices.push_back(memIndex);
   }
 


### PR DESCRIPTION
- use ValueRange where possible

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>