### PR TITLE
[Linalg] Add a Linalg iterator permutation transformation

### DIFF
--- a/include/mlir/Dialect/Linalg/Transforms/LinalgTransformPatterns.td
+++ b/include/mlir/Dialect/Linalg/Transforms/LinalgTransformPatterns.td
@@ -24,6 +24,7 @@
 
 include "mlir/Dialect/Linalg/IR/LinalgOps.td"
 include "mlir/Dialect/Linalg/IR/LinalgLibraryOps.td"
+include "mlir/Dialect/AffineOps/AffineOps.td"
 
 def HasNoLinalgTransformMarker : CPred<[{
   !$0.getAttrOfType<StringAttr>(LinalgTransforms::kLinalgTransformMarker)
@@ -37,6 +38,10 @@ class HasLinalgTransformMarker<string str> : CPred<[{
 
 class IsProducedByOpOfType<string str> :
   CPred<"isProducedByOpOfType<" # str # ">($0, $1)">;
+
+class AffineMapDomainHasDim<int n> : CPred<[{
+  $0.getAttrOfType<ArrayAttr>("indexing_maps").getValue()[0].
+  cast<AffineMapAttr>().getValue().getNumDims() ==}] # n # [{}]>;
 
 //===----------------------------------------------------------------------===//
 // Linalg fusion patterns.
@@ -86,4 +91,12 @@ class LinalgOpToVectorContraction<string OpType> : NativeCodeCall<
   "if (failed(vectorizeGenericOp($_builder, $0))) " #
   "  return matchFailure();">;
 
+//===----------------------------------------------------------------------===//
+// Linalg generic permutation patterns.
+//===----------------------------------------------------------------------===//
+class PermuteGenericLinalgOp<list<int> permutation, string value> :
+  NativeCodeCall<
+  "if (failed(permuteGenericLinalgOp($_builder, $0, {" #
+  StrJoinInt<permutation>.result # "}, \"" # value # "\"))) " #
+  "  return matchFailure();">;
 #endif // LINALG_TRANSFORMS

--- a/include/mlir/Dialect/Linalg/Transforms/LinalgTransforms.h
+++ b/include/mlir/Dialect/Linalg/Transforms/LinalgTransforms.h
@@ -90,6 +90,11 @@ LogicalResult linalgOpToAffineLoops(PatternRewriter &rewriter, Operation *op);
 // Rewrite a linalg.generic into a suitable vector.contraction op.
 LogicalResult vectorizeGenericOp(PatternRewriter &rewriter, Operation *op);
 
+// Emits a `generic` or `indexed_generic` operation with the `indexing_maps` and
+// `iterator_types` permutated according to `permutation`.
+LogicalResult permuteGenericLinalgOp(PatternRewriter &rewriter, Operation *op,
+                                     ArrayRef<unsigned> permutation,
+                                     StringRef linalgMarker);
 } // namespace linalg
 } // namespace mlir
 

--- a/include/mlir/Dialect/Linalg/Utils/Utils.h
+++ b/include/mlir/Dialect/Linalg/Utils/Utils.h
@@ -205,6 +205,18 @@ promoteSubViews(OpBuilder &b, Location loc, ArrayRef<Value *> subViews,
 /// tiling to just use the values when cloning `linalgOp`.
 llvm::SmallVector<Value *, 4> getAssumedNonViewOperands(LinalgOp linalgOp);
 
+/// Apply the permutation defined by `permutation` to `inVec`.
+/// Element `i` in `inVec` is mapped to location `j = permutation[i]`.
+/// E.g.: for an input vector `inVec = ['a', 'b', 'c']` and a permutation vector
+/// `permutation = [2, 0, 1]`, this function leaves `inVec = ['c', 'a', 'b']`.
+template <typename T, unsigned N>
+void applyPermutationToVector(SmallVector<T, N> &inVec,
+                              ArrayRef<unsigned> permutation) {
+  SmallVector<T, N> auxVec(inVec.size());
+  for (unsigned i = 0; i < permutation.size(); ++i)
+    auxVec[i] = inVec[permutation[i]];
+  inVec = auxVec;
+}
 } // namespace linalg
 } // namespace mlir
 

--- a/lib/Dialect/Linalg/Transforms/LinalgTransforms.cpp
+++ b/lib/Dialect/Linalg/Transforms/LinalgTransforms.cpp
@@ -22,8 +22,10 @@
 #include "mlir/Dialect/Linalg/Transforms/LinalgTransforms.h"
 #include "mlir/Dialect/Linalg/Analysis/DependenceAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Linalg/Utils/Intrinsics.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/VectorOps/VectorOps.h"
+#include "mlir/EDSC/Helpers.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
@@ -35,7 +37,10 @@
 #define DEBUG_TYPE "linalg-transforms"
 
 using namespace mlir;
+using namespace mlir::edsc;
+using namespace mlir::edsc::intrinsics;
 using namespace mlir::linalg;
+using namespace mlir::linalg::intrinsics;
 
 using llvm::dbgs;
 
@@ -191,5 +196,37 @@ LogicalResult mlir::linalg::vectorizeGenericOp(PatternRewriter &rewriter,
   auto vRes = vector_contract(vA, vB, vC, genericOp.indexing_maps(),
                               genericOp.iterator_types());
   std_store(vRes, vectorMemRefC);
+  return success();
+}
+
+LogicalResult
+mlir::linalg::permuteGenericLinalgOp(PatternRewriter &rewriter, Operation *op,
+                                     ArrayRef<unsigned> permutation,
+                                     StringRef linalgMarker) {
+  // If permutation is empty, there is nothing to be done.
+  if (permutation.size() == 0)
+    return failure();
+
+  auto linOp = cast<LinalgOp>(op);
+  auto permutationMap = inversePermutation(
+      AffineMap::getPermutationMap(permutation, rewriter.getContext()));
+  SmallVector<AffineMap, 4> newIndexingMap;
+  auto indexingMaps =
+      linOp.getAttrOfType<ArrayAttr>("indexing_maps").getValue();
+  for (unsigned i = 0, e = linOp.getNumInputsAndOutputs(); i != e; ++i) {
+    AffineMap m = indexingMaps[i].cast<AffineMapAttr>().getValue().compose(
+        permutationMap);
+    newIndexingMap.push_back(m);
+  }
+  auto itTypes = linOp.getAttrOfType<ArrayAttr>("iterator_types").getValue();
+  SmallVector<StringRef, 4> itTypesVector;
+  for (unsigned i = 0, e = itTypes.size(); i != e; ++i)
+    itTypesVector.push_back(itTypes[i].cast<StringAttr>().getValue());
+  applyPermutationToVector(itTypesVector, permutation);
+  op->setAttr("indexing_maps", rewriter.getAffineMapArrayAttr(newIndexingMap));
+  op->setAttr("iterator_types", rewriter.getStrArrayAttr(itTypesVector));
+  op->setAttr(LinalgTransforms::kLinalgTransformMarker,
+              rewriter.getStringAttr(linalgMarker));
+  linOp.clone(rewriter, linOp.getLoc(), op->getOperands());
   return success();
 }

--- a/lib/Dialect/Linalg/Transforms/Tiling.cpp
+++ b/lib/Dialect/Linalg/Transforms/Tiling.cpp
@@ -215,14 +215,6 @@ makeTiledViews(OpBuilder &b, Location loc, LinalgOp linalgOp,
   return res;
 }
 
-void applyPermutationToLoopRanges(SmallVector<SubViewOp::Range, 4> &loopRanges,
-                                  ArrayRef<unsigned> permutation) {
-  SmallVector<SubViewOp::Range, 4> auxVec(loopRanges.size());
-  for (unsigned i = 0; i < permutation.size(); ++i)
-    auxVec[i] = loopRanges[permutation[i]];
-  loopRanges = auxVec;
-}
-
 llvm::Optional<TiledLinalgOp> mlir::linalg::tileLinalgOp(
     OpBuilder &b, LinalgOp op, ArrayRef<Value *> tileSizes,
     ArrayRef<unsigned> permutation, OperationFolder *folder) {
@@ -256,7 +248,7 @@ llvm::Optional<TiledLinalgOp> mlir::linalg::tileLinalgOp(
       makeTiledLoopRanges(b, scope.getLocation(), viewSizesToLoopsMap,
                           viewSizes, tileSizes, folder);
   if (!permutation.empty())
-    applyPermutationToLoopRanges(loopRanges, permutation);
+    applyPermutationToVector(loopRanges, permutation);
 
   // 3. Create the tiled loops.
   LinalgOp res = op;

--- a/test/lib/DeclarativeTransforms/TestLinalgTransformPatterns.td
+++ b/test/lib/DeclarativeTransforms/TestLinalgTransformPatterns.td
@@ -87,4 +87,17 @@ def : Pattern<(GenericOp:$op $_1, $_2, $_3, $_4, $_5, $_6, $_7),
               [(LinalgOpToVectorContraction<"GenericOp"> $op)],
               [(Constraint<HasLinalgTransformMarker<"_marked_matmul_">> $op)]>;
 
+//===----------------------------------------------------------------------===//
+// Linalg generic permutation patterns.
+//===----------------------------------------------------------------------===//
+
+def : Pat<(GenericOp:$op $input, $imap, $itypes, $nviews, $doc, $fun, $libcall),
+              (PermuteGenericLinalgOp<[1,2,0],"PERMUTED"> $op),
+              [(Constraint<And<[HasNoLinalgTransformMarker,
+                           AffineMapDomainHasDim<3>]>> $op)]>;
+
+def : Pat<(IndexedGenericOp:$op $input, $imap, $itypes, $nviews, $doc, $fun, $libcall),
+              (PermuteGenericLinalgOp<[1,2,0],"PERMUTED"> $op),
+              [(Constraint<And<[HasNoLinalgTransformMarker,
+                           AffineMapDomainHasDim<3>]>> $op)]>;
 #endif // TEST_LINALG_TRANSFORMS_PATTERNS


### PR DESCRIPTION
This patch closes issue #272
We add a standalone iterator permutation transformation to Linalg.
This transformation composes a permutation map with the maps in the
"indexing_maps" attribute. It also permutes "iterator_types"
accordingly.

Change-Id: I7c1e693b8203aeecc595a7c012e738ca1100c857