### PR TITLE
Fix warning with struct forward declared as class

### DIFF
--- a/include/mlir/Analysis/LoopAnalysis.h
+++ b/include/mlir/Analysis/LoopAnalysis.h
@@ -32,7 +32,7 @@ class AffineExpr;
 class AffineForOp;
 class AffineMap;
 class MemRefType;
-class NestedPattern;
+struct NestedPattern;
 class Operation;
 class Value;
 


### PR DESCRIPTION
This is liable to cause mangling issue on Windows where class and struct are mangled differently.