### PR TITLE
Splat op doc - fix misformat / update tablegen op desc. comment

### DIFF
--- a/g3doc/Dialects/Standard.md
+++ b/g3doc/Dialects/Standard.md
@@ -373,10 +373,14 @@ Example:
 ```
 
 TODO: This operation is easy to extend to broadcast to dynamically shaped
-tensors in the same way dynamically shaped memrefs are handled. `mlir //
-Broadcasts %s to a 2-d dynamically shaped tensor, with %m, %n binding // to the
-sizes of the two dynamic dimensions. %m = "foo"() : () -> (index) %n = "bar"() :
-() -> (index) %t = splat %s [%m, %n] : tensor<?x?xi32>`
+tensors in the same way dynamically shaped memrefs are handled.
+```mlir {.mlir}
+// Broadcasts %s to a 2-d dynamically shaped tensor, with %m, %n binding
+// to the sizes of the two dynamic dimensions.
+%m = "foo"() : () -> (index)
+%n = "bar"() : () -> (index)
+%t = splat %s [%m, %n] : tensor<?x?xi32>
+```
 
 ### 'store' operation
 

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -1086,7 +1086,16 @@ def SplatOp : Std_Op<"splat", [NoSideEffect]> {
       %1 = splat %0 : vector<8xi32>
       %2 = splat %0 : tensor<4x8xi32>
 
-    // TODO: handle broadcast to dynamically shaped tensors.
+    TODO: Extend this operation to broadcast to dynamically shaped tensors in
+    the same way dynamically shaped memrefs are handled.
+
+    // Broadcasts %s to a 2-d dynamically shaped tensor, with %m, %n binding
+    // to the sizes of the two dynamic dimensions.
+
+      %m = "foo"() : () -> (index)
+      %n = "bar"() : () -> (index)
+      %t = splat %s [%m, %n] : tensor<?x?xi32>
+
   }];
 
   let arguments = (ins AnyTypeOf<[AnyInteger, AnyFloat],


### PR DESCRIPTION
- bring op description comment in sync with the doc
- fix misformat in doc

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>