### PR TITLE
fix a typo in OpDefinitions doc

### DIFF
--- a/g3doc/OpDefinitions.md
+++ b/g3doc/OpDefinitions.md
@@ -505,7 +505,7 @@ def MyOp : ... {
   let builders = [
     OpBuilder<"Builder *builder, OperationState &state, float val = 0.5f", [{
       state.addAttribute("attr", builder->getF32FloatAttr(val));
-    ]}>
+    }]>
   ];
 }
 ```


### PR DESCRIPTION
[{ matched with }], rather than ]}