### PR TITLE
Free ReturnOp from being restricted to a FuncOp

### DIFF
--- a/g3doc/Dialects/Standard.md
+++ b/g3doc/Dialects/Standard.md
@@ -72,10 +72,14 @@ Syntax:
 operation ::= `return` (ssa-use-list `:` type-list-no-parens)?
 ```
 
-The `return` terminator operation represents the completion of a function, and
-produces the result values. The count and types of the operands must match the
-result types of the enclosing function. It is legal for multiple blocks in a
-single function to return.
+The `return` terminator operation represents the transfer of control to its
+parent op, which is the op immediately enclosing the region in which the
+`return' appears.  The semantics of the parent op define where control flows
+next. When the parent op of a `return` is a function op, the `return' represents
+the completion of that function and produces its result values. The count and
+types of the operands must match the result types of that function. In the case
+that the parent op is not a function, the count and types of the return's
+operands must match those of the result values of the parent op.
 
 ## Core Operations
 

--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -1012,7 +1012,7 @@ def RemIUOp : IntArithmeticOp<"remiu"> {
   let hasFolder = 1;
 }
 
-def ReturnOp : Std_Op<"return", [Terminator, HasParent<"FuncOp">]> {
+def ReturnOp : Std_Op<"return", [Terminator]> {
   let summary = "return operation";
   let description = [{
     The "return" operation represents a return operation within a function.

--- a/test/IR/core-ops.mlir
+++ b/test/IR/core-ops.mlir
@@ -682,3 +682,12 @@ func @tensor_load_store(%0 : memref<4x4xi32>) {
   tensor_store %1, %0 : memref<4x4xi32>
   return
 }
+
+// CHECK-LABEL: func @return_in_op_with_region
+func @return_in_op_with_region() {
+  "foo.region"() ({
+    %c9 = constant 9 : i32
+    return %c9 : i32
+  }): () -> (i32)
+  return
+}

--- a/test/IR/invalid-ops.mlir
+++ b/test/IR/invalid-ops.mlir
@@ -693,9 +693,9 @@ func @trunci_cast_to_same_width(%arg0 : i16) {
 
 func @return_not_in_function() {
   "foo.region"() ({
-    // expected-error@+1 {{'std.return' op expects parent op 'func'}}
+    // expected-error@+1 {{'std.return' op has 0 operands, but enclosing function returns 1}}
     return
-  }): () -> ()
+  }): () -> (i32)
   return
 }
 


### PR DESCRIPTION
- allow return op to be used from the top level of any op with a region
  (as opposed to just from the top level of a func op)
- the return operand count/types should match the op results' (whenever
  it's not in a FuncOp's region).

This allows std.return to be used both in a declarative (FuncOp) as well as an
imperative (typical op) setting --- avoiding the need to create custom
return ops for what is standard, in cases where control is to be
transferred to the enclosing operation, and return values need to be
modeled in ops with regions.

This also enables affine.graybox to hold a list of blocks with terminators.

Signed-off-by: Uday Bondhugula <uday@polymagelabs.com>