### PR TITLE
Add uitofp to the standard dialect.

### DIFF
--- a/include/mlir/Dialect/StandardOps/Ops.td
+++ b/include/mlir/Dialect/StandardOps/Ops.td
@@ -1144,7 +1144,7 @@ def UnsignedShiftRightOp : IntArithmeticOp<"shift_right_unsigned"> {
 }
 
 def SIToFPOp : CastOp<"sitofp">, Arguments<(ins AnyType:$in)> {
-  let summary = "cast from integer type to floating-point";
+  let summary = "cast from signed integer type to floating-point";
   let description = [{
     Cast from a value interpreted as signed integer to the corresponding
     floating-point value. If the value cannot be exactly represented, it is
@@ -1530,6 +1530,24 @@ def TruncateIOp : Std_Op<"trunci", [NoSideEffect, SameOperandsAndResultShape]> {
   let printer = [{
     return printStandardCastOp(this->getOperation(), p);
   }];
+}
+
+def UIToFPOp : CastOp<"uitofp">, Arguments<(ins AnyType:$in)> {
+  let summary = "cast from unsigned integer type to floating-point";
+  let description = [{
+    Cast from a value interpreted as unsigned integer to the corresponding
+    floating-point value. If the value cannot be exactly represented, it is
+    rounded using the default rounding mode. Only scalars are currently
+    supported.
+  }];
+
+  let extraClassDeclaration = [{
+    /// Return true if `a` and `b` are valid operand and result pairs for
+    /// the operation.
+    static bool areCastCompatible(Type a, Type b);
+  }];
+
+  let hasFolder = 0;
 }
 
 def ViewOp : Std_Op<"view", [NoSideEffect]> {

--- a/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
+++ b/lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp
@@ -1608,6 +1608,10 @@ struct SIToFPLowering
     : public OneToOneLLVMOpLowering<SIToFPOp, LLVM::SIToFPOp> {
   using Super::Super;
 };
+struct UIToFPLowering
+    : public OneToOneLLVMOpLowering<UIToFPOp, LLVM::UIToFPOp> {
+  using Super::Super;
+};
 
 struct FPExtLowering : public OneToOneLLVMOpLowering<FPExtOp, LLVM::FPExtOp> {
   using Super::Super;
@@ -2125,6 +2129,7 @@ void mlir::populateStdToLLVMNonMemoryConversionPatterns(
       SubIOpLowering,
       TanhOpLowering,
       TruncateIOpLowering,
+      UIToFPLowering,
       UnsignedDivIOpLowering,
       UnsignedRemIOpLowering,
       UnsignedShiftRightOpLowering,

--- a/lib/Dialect/StandardOps/Ops.cpp
+++ b/lib/Dialect/StandardOps/Ops.cpp
@@ -1985,6 +1985,15 @@ bool SIToFPOp::areCastCompatible(Type a, Type b) {
 }
 
 //===----------------------------------------------------------------------===//
+// UIToFPOp
+//===----------------------------------------------------------------------===//
+
+// uitofp is applicable from integer types to float types.
+bool UIToFPOp::areCastCompatible(Type a, Type b) {
+  return SIToFPOp::areCastCompatible(a, b);
+}
+
+//===----------------------------------------------------------------------===//
 // SelectOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
+++ b/test/Conversion/StandardToLLVM/convert-to-llvmir.mlir
@@ -457,8 +457,8 @@ func @index_cast(%arg0: index, %arg1: i1) {
 }
 
 // Checking conversion of integer types to floating point.
-// CHECK-LABEL: @sitofp
-func @sitofp(%arg0 : i32, %arg1 : i64) {
+// CHECK-LABEL: @sitofp_uitofp
+func @sitofp_uitofp(%arg0 : i32, %arg1 : i64) {
 // CHECK-NEXT: = llvm.sitofp {{.*}} : !llvm.i{{.*}} to !llvm.float
   %0 = sitofp %arg0: i32 to f32
 // CHECK-NEXT: = llvm.sitofp {{.*}} : !llvm.i{{.*}} to !llvm.double
@@ -467,6 +467,15 @@ func @sitofp(%arg0 : i32, %arg1 : i64) {
   %2 = sitofp %arg1: i64 to f32
 // CHECK-NEXT: = llvm.sitofp {{.*}} : !llvm.i{{.*}} to !llvm.double
   %3 = sitofp %arg1: i64 to f64
+
+// CHECK-NEXT: = llvm.uitofp {{.*}} : !llvm.i{{.*}} to !llvm.float
+  %4 = uitofp %arg0: i32 to f32
+// CHECK-NEXT: = llvm.uitofp {{.*}} : !llvm.i{{.*}} to !llvm.double
+  %5 = uitofp %arg0: i32 to f64
+// CHECK-NEXT: = llvm.uitofp {{.*}} : !llvm.i{{.*}} to !llvm.float
+  %6 = uitofp %arg1: i64 to f32
+// CHECK-NEXT: = llvm.uitofp {{.*}} : !llvm.i{{.*}} to !llvm.double
+  %7 = uitofp %arg1: i64 to f64
   return
 }
 

--- a/test/IR/core-ops.mlir
+++ b/test/IR/core-ops.mlir
@@ -494,6 +494,18 @@ func @standard_instrs(tensor<4x4x?xf32>, f32, i32, index, i64, f16) {
   // CHECK: %{{[0-9]+}} = shift_right_unsigned %cst_4, %cst_4 : tensor<42xi32>
   %138 = shift_right_unsigned %tci32, %tci32 : tensor<42 x i32>
 
+  // CHECK: = uitofp {{.*}} : i32 to f32
+  %139 = uitofp %i : i32 to f32
+
+  // CHECK: = uitofp {{.*}} : i32 to f64
+  %140 = uitofp %i : i32 to f64
+
+  // CHECK: = uitofp {{.*}} : i64 to f32
+  %141 = uitofp %j : i64 to f32
+
+  // CHECK: = uitofp {{.*}} : i64 to f64
+  %142 = uitofp %j : i64 to f64
+
   return
 }
 

--- a/test/IR/invalid-ops.mlir
+++ b/test/IR/invalid-ops.mlir
@@ -531,6 +531,22 @@ func @sitofp_f32_to_i32(%arg0 : f32) {
 
 // -----
 
+func @uitofp_i32_to_i64(%arg0 : i32) {
+  // expected-error@+1 {{are cast incompatible}}
+  %0 = uitofp %arg0 : i32 to i64
+  return
+}
+
+// -----
+
+func @uitofp_f32_to_i32(%arg0 : f32) {
+  // expected-error@+1 {{are cast incompatible}}
+  %0 = uitofp %arg0 : f32 to i32
+  return
+}
+
+// -----
+
 func @fpext_f32_to_f16(%arg0 : f32) {
   // expected-error@+1 {{are cast incompatible}}
   %0 = fpext %arg0 : f32 to f16


### PR DESCRIPTION
The operation 'uitofp', which converts an unsigned integer to a floating-point
value was already part of the LLVM dialect. Contrary to its sibling 'sitofp' it
had no corresponding operation in the standard dialect.

This adds UIToFPOp to the standard dialect and a lowering to 'uitofp' in LLVM.
The work is mostly copy-paste of the existing SIToFPOp.